### PR TITLE
feat(api): add user profile endpoint

### DIFF
--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class UserProfileController extends Controller
+{
+    public function show(Request $request)
+    {
+        $token = $request->input('token') ?: $request->bearerToken();
+
+        if (!$token) {
+            return response()->json([
+                'status_code' => 0,
+                'message' => 'Token not provided',
+            ], 401);
+        }
+
+        $accessToken = PersonalAccessToken::findToken($token);
+
+        if (!$accessToken || !$accessToken->tokenable) {
+            return response()->json([
+                'status_code' => 0,
+                'message' => 'Invalid token',
+            ], 401);
+        }
+
+        $tokenUser = $accessToken->tokenable;
+
+        $profile = DB::table('tbluser as u')
+            ->join('tbluserprofilemaster as up', function ($join) {
+                $join->on('up.id', '=', 'u.user_profile_id')
+                    ->on('up.sub_institute_id', '=', 'u.sub_institute_id');
+            })
+            ->leftJoin('school_setup as ss', 'ss.id', '=', 'u.sub_institute_id')
+            ->leftJoin('hrms_departments as hd', 'hd.id', '=', 'u.department_id')
+            ->leftJoin('s_user_jobrole as jr', 'jr.id', '=', 'u.allocated_standards')
+            ->selectRaw("
+                u.id,
+                u.user_name,
+                u.first_name,
+                u.middle_name,
+                u.last_name,
+                CONCAT_WS(' ', NULLIF(u.first_name, ''), NULLIF(u.middle_name, ''), NULLIF(u.last_name, '')) as full_name,
+                u.email,
+                u.mobile,
+                u.birthdate,
+                u.address,
+                u.gender,
+                u.join_year,
+                u.employee_no,
+                u.employee_id,
+                u.image,
+                u.user_profile_id,
+                up.name as user_profile_name,
+                u.sub_institute_id,
+                u.client_id,
+                u.is_admin,
+                u.status,
+                u.department_id,
+                IFNULL(hd.department, '-') as department_name,
+                u.allocated_standards as jobrole_id,
+                IFNULL(jr.jobrole, '-') as jobrole_name,
+                ss.SchoolName as school_name,
+                ss.ShortCode as school_short_code,
+                ss.Logo as school_logo,
+                ss.syear
+            ")
+            ->where('u.id', $tokenUser->id)
+            ->first();
+
+        if (!$profile) {
+            return response()->json([
+                'status_code' => 0,
+                'message' => 'Profile details not found',
+            ], 404);
+        }
+
+        $baseUrl = rtrim($request->getSchemeAndHttpHost(), '/');
+        $profile->image = !empty($profile->image) ? $baseUrl . '/storage/user/' . ltrim($profile->image, '/') : '';
+        $profile->school_logo = !empty($profile->school_logo) ? $baseUrl . '/admin_dep/images/' . ltrim($profile->school_logo, '/') : '';
+
+        return response()->json([
+            'status_code' => 1,
+            'message' => 'Profile details fetched successfully',
+            'data' => $profile,
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,6 +57,7 @@ use App\Http\Controllers\Api\signup_api\UserSignupController;
 use App\Http\Controllers\Api\SkillHeatmapController;
 use App\Http\Controllers\signupOtpController;
 use App\Http\Controllers\Api\UserImportController;
+use App\Http\Controllers\Api\UserProfileController;
 use App\Http\Controllers\HRMS\DepartmentJobRoleExportController;
 use App\Http\Controllers\HRMS\DepartmentSkillController;
 use App\Http\Controllers\HRTemplates\TemplateController;
@@ -66,6 +67,7 @@ use App\Http\Controllers\NewsletterController;
 Route::post('/send-otp', [signupOtpController::class, 'sendOtp']);
 Route::post('/verify-otp', [signupOtpController::class, 'verifyOtp']);
 Route::post('/newsletter/send', [NewsletterController::class, 'sendNewsletter']);
+Route::match(['get', 'post'], '/user/profile', [UserProfileController::class, 'show']);
 
 Route::get('/jobroles/{jobRoleId}/graph', [JobRoleGraphController::class, 'show']);
 Route::get('/organizations/{orgId}/graph', [OrganizationGraphController::class, 'show']);


### PR DESCRIPTION
Add a new API endpoint `/user/profile` that returns authenticated user profile details. The endpoint accepts both GET and POST requests with a token for authentication and returns comprehensive user information including personal details, department, job role, and school information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve authenticated user profile information, including full name, department, job role, and school metadata. Supports token-based authentication via request parameters or HTTP Bearer tokens. Returns appropriate error responses for missing or invalid authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->