### PR TITLE
fix: filter out users without sub_institute in profile query

### DIFF
--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -76,6 +76,7 @@ class UserProfileController extends Controller
                 ss.syear
             ")
             ->where('u.id', $tokenUser->id)
+            ->whereNotNull('u.sub_institute_id')
             ->first();
 
         if (!$profile) {


### PR DESCRIPTION
Prevents null reference errors when accessing profile data for users who lack a sub-institute assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User profiles now require a specific attribute to be accessible; profiles missing this attribute will return a "not found" response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->