### PR TITLE
feat(user-rights): add mobile-specific permission flag

### DIFF
--- a/app/Http/Controllers/user/tblgroupwise_rightsController.php
+++ b/app/Http/Controllers/user/tblgroupwise_rightsController.php
@@ -155,6 +155,7 @@ class tblgroupwise_rightsController extends Controller
                 'menu_id' => $key,
                 'profile_id' => $request->input('profile_id'),
                 'sub_institute_id' => $sub_institute_id,
+                'is_mobile' => $request->input('is_mobile', 0),
                 'created_at' => now(),
             );
 
@@ -224,25 +225,40 @@ class tblgroupwise_rightsController extends Controller
             return response()->json(['status_code' => 0, 'message' => $validator->errors()->first()], 400);
         }
         $sub_institute_id = $request->get('sub_institute_id');
+        $is_mobile = $request->input('is_mobile');
         // }
 
-        $data = tblmenumasterModel::where(['LEVEL' => 1, 'status' => 1])
-            ->whereRaw('FIND_IN_SET(?, sub_institute_id)', [$sub_institute_id])
-            ->groupBy('tblmenumaster.id')
+        $allowed_menu_ids = null;
+        if ($is_mobile !== null) {
+            $allowed_menu_ids = tblgroupwise_rightsModel::where(['profile_id' => $profile_id, 'is_mobile' => $is_mobile])->pluck('menu_id')->toArray();
+        }
+
+        $dataQuery = tblmenumasterModel::where(['LEVEL' => 1, 'status' => 1])
+            ->whereRaw('FIND_IN_SET(?, sub_institute_id)', [$sub_institute_id]);
+        if ($allowed_menu_ids) {
+            $dataQuery->whereIn('id', $allowed_menu_ids);
+        }
+        $data = $dataQuery->groupBy('tblmenumaster.id')
             ->orderBy('tblmenumaster.sort_order', 'ASC')
             ->get()
             ->toArray();
 
 
-        $subMenuData = tblmenumasterModel::where(['LEVEL' => 2, 'status' => 1])
-            ->whereRaw('FIND_IN_SET(?, sub_institute_id)', [$sub_institute_id])
-            ->orderBy('tblmenumaster.sort_order', 'ASC')
+        $subMenuQuery = tblmenumasterModel::where(['LEVEL' => 2, 'status' => 1])
+            ->whereRaw('FIND_IN_SET(?, sub_institute_id)', [$sub_institute_id]);
+        if ($allowed_menu_ids) {
+            $subMenuQuery->whereIn('id', $allowed_menu_ids);
+        }
+        $subMenuData = $subMenuQuery->orderBy('tblmenumaster.sort_order', 'ASC')
             ->get()
             ->toArray();
 
-        $SubsubMenuData = tblmenumasterModel::where(['LEVEL' => 3, 'status' => 1])
-            ->whereRaw('FIND_IN_SET(?, sub_institute_id)', [$sub_institute_id])
-            ->orderBy('tblmenumaster.sort_order', 'ASC')
+        $SubsubMenuQuery = tblmenumasterModel::where(['LEVEL' => 3, 'status' => 1])
+            ->whereRaw('FIND_IN_SET(?, sub_institute_id)', [$sub_institute_id]);
+        if ($allowed_menu_ids) {
+            $SubsubMenuQuery->whereIn('id', $allowed_menu_ids);
+        }
+        $SubsubMenuData = $SubsubMenuQuery->orderBy('tblmenumaster.sort_order', 'ASC')
             ->get()
             ->toArray();
 
@@ -256,6 +272,7 @@ class tblgroupwise_rightsController extends Controller
             $data[$i]['can_edit'] = $rights->can_edit ?? 0;
             $data[$i]['can_delete'] = $rights->can_delete ?? 0;
             $data[$i]['dashboard_right'] = $rights->dashboard_right ?? 0;
+            $data[$i]['is_mobile'] = $rights->is_mobile ?? 0;
             $i++;
         }
 
@@ -269,6 +286,7 @@ class tblgroupwise_rightsController extends Controller
             $finalSubMenu[$value['parent_id']][$i]['can_edit'] = $rights->can_edit ?? 0;
             $finalSubMenu[$value['parent_id']][$i]['can_delete'] = $rights->can_delete ?? 0;
             $finalSubMenu[$value['parent_id']][$i]['dashboard_right'] = $rights->dashboard_right ?? 0;
+            $finalSubMenu[$value['parent_id']][$i]['is_mobile'] = $rights->is_mobile ?? 0;
             $i++;
         }
 
@@ -282,6 +300,7 @@ class tblgroupwise_rightsController extends Controller
             $finalSubSubMenu[$value['parent_id']][$i]['can_edit'] = $rights->can_edit ?? 0;
             $finalSubSubMenu[$value['parent_id']][$i]['can_delete'] = $rights->can_delete ?? 0;
             $finalSubSubMenu[$value['parent_id']][$i]['dashboard_right'] = $rights->dashboard_right ?? 0;
+            $finalSubSubMenu[$value['parent_id']][$i]['is_mobile'] = $rights->is_mobile ?? 0;
             $i++;
         }
 

--- a/app/Models/user/tblgroupwise_rightsModel.php
+++ b/app/Models/user/tblgroupwise_rightsModel.php
@@ -17,6 +17,7 @@ class tblgroupwise_rightsModel extends Model
         'can_add',
         'can_edit',
         'can_delete',
+        'is_mobile',
         'created_at',
         'sub_institute_id'
     ];

--- a/database/migrations/2026_04_13_155137_add_is_mobile_to_tblgroupwise_rights_table.php
+++ b/database/migrations/2026_04_13_155137_add_is_mobile_to_tblgroupwise_rights_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('tblgroupwise_rights')) {
+            return;
+        }
+
+        if (!Schema::hasColumn('tblgroupwise_rights', 'is_mobile')) {
+            Schema::table('tblgroupwise_rights', function (Blueprint $table) {
+                $table->boolean('is_mobile')->nullable();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (!Schema::hasTable('tblgroupwise_rights')) {
+            return;
+        }
+
+        if (Schema::hasColumn('tblgroupwise_rights', 'is_mobile')) {
+            Schema::table('tblgroupwise_rights', function (Blueprint $table) {
+                $table->dropColumn('is_mobile');
+            });
+        }
+    }
+};


### PR DESCRIPTION
Add `is_mobile` boolean column to groupwise rights to distinguish between web and mobile permissions. Update model fillable fields, create migration, and modify controller to handle mobile-specific menu filtering and rights assignment. This enables separate permission sets for mobile app access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mobile-specific permission settings in group-wise rights management. Menu access can now be controlled separately for mobile and web platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->