### PR TITLE
feat: add mobile access flag to group rights management

### DIFF
--- a/app/Http/Controllers/user/tblgroupwise_rightsController.php
+++ b/app/Http/Controllers/user/tblgroupwise_rightsController.php
@@ -129,6 +129,7 @@ class tblgroupwise_rightsController extends Controller
         $deleteRights = $request->input('delete');
         $viewRights = $request->input('view');
         $dashboardRights = $request->input('dashboard');
+        $is_mobile = $request->input('is_mobile');
 
         if (!isset($addRights)) {
             $addRights = array();
@@ -144,6 +145,9 @@ class tblgroupwise_rightsController extends Controller
         }
          if (!isset($dashboardRights)) {
             $dashboardRights = array();
+        }
+        if (!isset($is_mobile)) {
+            $is_mobile = array();
         }
 
         $arrayKeys = array_replace($addRights, $editRights, $deleteRights, $viewRights,$dashboardRights);
@@ -173,6 +177,9 @@ class tblgroupwise_rightsController extends Controller
             }
               if (isset($dashboardRights[$key])) {
                 $finalArray['dashboard_right'] = 1;
+            }
+            if (isset($is_mobile[$key])) {
+                $finalArray['is_mobile'] = 1;
             }
             $insert = tblgroupwise_rightsModel::insert($finalArray);
             if ($insert) {


### PR DESCRIPTION
Introduce 'is_mobile' field to control mobile access permissions in group rights assignments. This allows administrators to grant or restrict mobile platform access separately from other rights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended group rights configuration to include mobile-specific flags alongside existing permission controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->