### PR TITLE
feat(api): add career journey endpoint

### DIFF
--- a/app/Http/Controllers/CareerJourneyController.php
+++ b/app/Http/Controllers/CareerJourneyController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class CareerJourneyController extends Controller
+{
+    public function getCareerJourney(Request $request)
+    {
+        $userId = $request->user_id;
+        $subInstituteId = $request->sub_institute_id;
+
+        // 1. Get user's current jobrole
+        $user = DB::table('tbluser')
+            ->where('id', $userId)
+            ->first();
+
+        if (!$user) {
+            return response()->json(['status' => false, 'message' => 'User not found']);
+        }
+
+        $currentJobRoleId = $user->allocated_standards;
+
+        // 2. Get all career journey steps for that sub institute
+        $journeys = DB::table('career_journey')
+            ->where('sub_institute_id', $subInstituteId)
+            ->orderBy('id')
+            ->get();
+
+        $result = [];
+
+        foreach ($journeys as $journey) {
+
+            // Get TO job role details
+            $toRole = DB::table('s_user_jobrole')
+                ->where('id', $journey->to_jobrole_id)
+                ->first();
+
+            if (!$toRole) continue;
+
+            // Status logic
+            $status = 'upcoming';
+
+            if ($journey->jobrole_id == $currentJobRoleId) {
+                $status = 'current';
+            } elseif ($journey->jobrole_id < $currentJobRoleId) {
+                $status = 'completed';
+            }
+
+            $result[] = [
+                'id' => $journey->id,
+                'from_jobrole_id' => $journey->jobrole_id,
+                'to_jobrole_id' => $journey->to_jobrole_id,
+
+                'role_name' => $toRole->jobrole,
+                'job_level' => $toRole->job_level, // MID / SENIOR
+
+                'movement_type' => $journey->vertical_lateral_movement == 1 ? 'vertical' : 'lateral',
+
+                'status' => $status,
+
+                // Optional UI percentage
+                'progress' => $status == 'current' ? '100%' :
+                              ($status == 'completed' ? '100%' : '0%')
+            ];
+        }
+
+        return response()->json([
+            'status' => true,
+            'data' => $result
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,7 @@ use App\Http\Controllers\HRMS\DepartmentJobRoleExportController;
 use App\Http\Controllers\HRMS\DepartmentSkillController;
 use App\Http\Controllers\HRTemplates\TemplateController;
 use App\Http\Controllers\NewsletterController;
+use App\Http\Controllers\CareerJourneyController;
 
 
 Route::post('/send-otp', [signupOtpController::class, 'sendOtp']);
@@ -270,3 +271,5 @@ Route::get('/export-department-jobroles/{subInstituteId}', [DepartmentJobRoleExp
 Route::resource('templates', TemplateController::class);
 Route::get('templates/{id}/versions', [TemplateController::class, 'versions']);
 Route::post('templates/{id}/restore/{version}', [TemplateController::class, 'restore']);
+
+Route::get('/career-journey', [CareerJourneyController::class, 'getCareerJourney']);


### PR DESCRIPTION
Add a new GET route '/career-journey' that retrieves career journey data via the CareerJourneyController. Includes the creation of the CareerJourneyController class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new career journey endpoint that retrieves comprehensive career progression information for users, including their current role status, job level details, movement type (vertical or lateral transitions), and progress tracking for each advancement step.
  * Users can now access and view their complete career advancement pathway with detailed status indicators (completed, current, or upcoming) for each career stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->