### PR TITLE
feat(career-journey): include user name in career journey response

### DIFF
--- a/app/Http/Controllers/CareerJourneyController.php
+++ b/app/Http/Controllers/CareerJourneyController.php
@@ -22,7 +22,7 @@ class CareerJourneyController extends Controller
 
         // 1. Get user
         $user = DB::table('tbluser')
-            ->select('id', 'allocated_standards', 'sub_institute_id')
+            ->select('id', 'first_name', 'middle_name', 'last_name', 'allocated_standards', 'sub_institute_id')
             ->where('id', $userId)
             ->where('sub_institute_id', $subInstituteId)
             ->first();
@@ -85,6 +85,10 @@ class CareerJourneyController extends Controller
 
         return response()->json([
             'status' => true,
+            'user' => [
+                'id' => $user->id,
+                'name' => trim(($user->first_name ?? '').' '.($user->middle_name ?? '').' '.($user->last_name ?? '')),
+            ],
             'current_jobrole' => [
                 'id' => $currentJobRole->id,
                 'jobrole' => $currentJobRole->jobrole,


### PR DESCRIPTION
Update the `getCareerJourney` method to select user name fields and include a formatted name in the JSON response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Career journey endpoint responses now include user identification and full name information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->