### PR TITLE
refactor(api): remove deprecated gemini models from fallback list

### DIFF
--- a/app/Http/Controllers/AJAXController.php
+++ b/app/Http/Controllers/AJAXController.php
@@ -932,9 +932,7 @@ class AJAXController extends Controller
         // Fallback model list - ordered from preferred → fallback (Feb 2026 reality)
         $modelsToTry = [
             'gemini-2.5-flash',         // Fast, cheap, stable GA
-            'gemini-flash-latest',      // Alias to newest Flash (good longevity)
-            'gemini-2.5-pro',           // Stronger reasoning when needed
-            'gemini-3-flash-preview',   // Newer preview (if your project allows)
+               // Newer preview (if your project allows)
             // Add more previews/experimental if needed: 'gemini-3-pro-preview', etc.
         ];
 


### PR DESCRIPTION
Remove `gemini-flash-latest`, `gemini-2.5-pro`, and `gemini-3-flash-preview` from the `$modelsToTry` array in `AJAXController` to clean up the fallback model list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model fallback configuration to prioritize newer model versions, improving service reliability and response quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->