### PR TITLE
feat(talent): add report manager and punch times to talent offers

### DIFF
--- a/app/Http/Controllers/talent/TalentOfferController.php
+++ b/app/Http/Controllers/talent/TalentOfferController.php
@@ -65,6 +65,9 @@ class TalentOfferController extends Controller
             'notes' => 'nullable|string',
             'sub_institute_id' => 'required|integer',
             'user_id' => 'required|integer',
+            'reportmanager' => 'nullable|string',
+            'punchintime' => 'nullable|date_format:H:i',
+            'punchouttime' => 'nullable|date_format:H:i',
         ]);
 
         if ($validator->fails()) {
@@ -85,6 +88,9 @@ class TalentOfferController extends Controller
                 'notes' => $request->notes,
                 'sub_institute_id' => $sub_institute_id,
                 'created_by' => $request->user_id,
+                'reportmanager' => $request->reportmanager,
+                'punchintime' => $request->punchintime,
+                'punchouttime' => $request->punchouttime,
                 'status' => 'draft', // default status
             ]);
 

--- a/app/Models/talent/TalentOffer.php
+++ b/app/Models/talent/TalentOffer.php
@@ -20,6 +20,9 @@ class TalentOffer extends Model
         'notes',
         'sub_institute_id',
         'created_by',
+        'reportmanager',
+        'punchintime',
+        'punchouttime',
         'sent_at',
         'rejected_at',
     ];

--- a/database/migrations/2026_05_06_000000_add_reportmanager_punch_times_to_talent_offers_table.php
+++ b/database/migrations/2026_05_06_000000_add_reportmanager_punch_times_to_talent_offers_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('talent_offers', function (Blueprint $table) {
+            $table->unsignedBigInteger('reportmanager')->nullable()->after('created_by');
+            $table->time('punchintime')->nullable()->after('reportmanager');
+            $table->time('punchouttime')->nullable()->after('punchintime');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('talent_offers', function (Blueprint $table) {
+            $table->dropColumn(['reportmanager', 'punchintime', 'punchouttime']);
+        });
+    }
+};


### PR DESCRIPTION
Add new columns `reportmanager`, `punchintime`, and `punchouttime` to the `talent_offers` table via a new migration. Update the `TalentOffer` model and `TalentOfferController` to support these new fields during storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Talent offers now include three new fields: Report Manager, Punch In Time, and Punch Out Time. These can be configured when creating or managing talent offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->