### PR TITLE
refactor(talent): join hrms_departments to fetch department name in j…

### DIFF
--- a/app/Http/Controllers/talent/talent_jobpostingcontroller.php
+++ b/app/Http/Controllers/talent/talent_jobpostingcontroller.php
@@ -58,7 +58,8 @@ class talent_jobpostingcontroller extends Controller
 
                 // fetch jobrole data from table
                 $talent = DB::table('talent_job_postings as a')
-                            ->select('*')
+                            ->leftJoin('hrms_departments as d', 'a.department_id', '=', 'd.id')
+                            ->select('a.*', 'd.department as department_name')
                             ->where('a.sub_institute_id',$sub_institute_id)
                             ->whereNull('a.deleted_at')
                             ->get();


### PR DESCRIPTION
…ob postings

Update the talent job posting index query to left join with the hrms_departments table. This allows the retrieval of the department name alongside the job posting data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job postings API responses now enriched with department information, enabling better context and filtering capabilities for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->