### PR TITLE
fix(user): remove redundant return statement in teacherListAPI

### DIFF
--- a/app/Http/Controllers/user/tbluserController.php
+++ b/app/Http/Controllers/user/tbluserController.php
@@ -955,9 +955,6 @@ class tbluserController extends Controller
         return json_encode($res);
     }
 
-        return json_encode($res);
-    }
-
     public function addUserDocument(Request $request, $id)
     {
         $type = $request->type;


### PR DESCRIPTION
Remove an unreachable return statement and extra closing brace in `tbluserController.php` to clean up the `teacherListAPI` method.