### PR TITLE
feat(api): move FCM token update route to api routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -58,6 +58,7 @@ use App\Http\Controllers\Api\signup_api\UserSignupController;
 use App\Http\Controllers\Api\SkillHeatmapController;
 use App\Http\Controllers\signupOtpController;
 use App\Http\Controllers\Api\UserImportController;
+use App\Http\Controllers\user\tbluserController;
 use App\Http\Controllers\Api\ExcelAutomationAgentController;
 use App\Http\Controllers\Api\UserProfileController;
 use App\Http\Controllers\HRMS\DepartmentJobRoleExportController;
@@ -248,6 +249,8 @@ Route::post('/user-signup', [UserSignupController::class, 'store']);
 Route::get('/user-signup/{id}', [UserSignupController::class, 'show']);
 Route::put('/user-signup/{id}', [UserSignupController::class, 'update']);
 Route::delete('/user-signup/{id}', [UserSignupController::class, 'destroy']);
+
+Route::post('/update-fcm-token', [tbluserController::class, 'updateFcmToken']);
 
 // Skill Heatmap API Routes
 Route::prefix('skill-heatmap')->group(function () {

--- a/routes/user.php
+++ b/routes/user.php
@@ -55,4 +55,3 @@ Route::group(['prefix' => 'user', 'middleware' => ['auth','session','menu']], fu
 });
 
 Route::post('/teacherListAPI', [tbluserController::class, 'teacherListAPI']);
-Route::post('/update-fcm-token', [tbluserController::class, 'updateFcmToken']);


### PR DESCRIPTION
Relocate the `/update-fcm-token` endpoint from `routes/user.php` to `routes/api.php` to ensure it is accessible via the API middleware stack.