### PR TITLE
feat(api): map calendar status and date from CSV during bulk import

### DIFF
--- a/app/Http/Controllers/front_desk/BulkTaskController.php
+++ b/app/Http/Controllers/front_desk/BulkTaskController.php
@@ -125,9 +125,29 @@ class BulkTaskController extends Controller
                 }
 
                 $task_type = $taskValue['task_type'] ?? 'Medium';
+                
                 $task_date = $taskValue['TASK_DATE'] ?? date('Y-m-d');
+                if (!empty($taskValue['Calendar Start Date & Time'])) {
+                    $parsedDate = strtotime($taskValue['Calendar Start Date & Time']);
+                    if ($parsedDate !== false) {
+                        $task_date = date('Y-m-d', $parsedDate);
+                    }
+                }
+
                 $repeat_days = (int)($taskValue['repeat_days'] ?? 1);
                 $repeat_until = $taskValue['repeat_until'] ?? null;
+
+                $calendarStatus = trim($taskValue['Calendar Status'] ?? '');
+                
+                // Map calendar status to task status
+                $taskStatus = 'PENDING'; // Default
+                if (strcasecmp($calendarStatus, 'Planned') === 0) {
+                    $taskStatus = 'Pending';
+                } elseif (strcasecmp($calendarStatus, 'Held') === 0) {
+                    $taskStatus = 'COMPLETED';
+                } elseif (strcasecmp($calendarStatus, 'In Progress') === 0) {
+                    $taskStatus = 'IN PROGRESS';
+                }
 
                 // Get repeating dates
                 $dates = $this->getDatesWithoutSundays($task_type, $task_date, $repeat_days, $repeat_until);
@@ -141,7 +161,7 @@ class BulkTaskController extends Controller
                     'task_type'                => $task_type,
                     'TASK_ALLOCATED_TO'        => $allocatedUserId,
                     'created_by'               => $user_id,
-                    'STATUS'                   => 'PENDING',
+                    'STATUS'                   => $taskStatus,
                     'created_at'               => now(),
                     'updated_at'               => now(),
                 ];


### PR DESCRIPTION
Update the bulk task import logic to extract and map additional fields from the CSV file:
- Parse 'Calendar Start Date & Time' to set the task date.
- Map 'Calendar Status' (Planned, Held, In Progress) to the corresponding internal task status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk task import now respects custom task dates from Calendar Start Date & Time field.
  * Bulk task import now preserves task status values from Calendar Status field (Planned, Held, In Progress).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rajeshrafaliyatriz/hp_erp/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->