### PR TITLE
fix(auth): add fallback for empty school lookup

### DIFF
--- a/app/Http/Controllers/Api/GoogleAuthController.php
+++ b/app/Http/Controllers/Api/GoogleAuthController.php
@@ -117,6 +117,13 @@ class GoogleAuthController extends Controller
                 $client_sub_institute_id = $schools[0]->id ?? '';
                 session()->put('syear', $schools[0]->syear ?? '');
             }
+            if (empty($client_sub_institute_id) && !empty($user->sub_institute_id)) {
+                $client_sub_institute_id = $user->sub_institute_id;
+                $fallbackSchool = DB::table('school_setup')->where('id', $user->sub_institute_id)->first();
+                if ($fallbackSchool) {
+                    session()->put('syear', $fallbackSchool->syear ?? '');
+                }
+            }
 
             if ($user->is_admin == 2) {
                 $getTermId = DB::table('academic_year')

--- a/app/Http/Controllers/auth/authController.php
+++ b/app/Http/Controllers/auth/authController.php
@@ -168,13 +168,21 @@ class authController extends Controller
                 if ($user['is_admin'] == 2) {
                     $schools = DB::table('school_setup')->whereIn('client_id', [2, 11, 20, 34, 81])->get()->toArray();
                 } else {
-                    $schools = DB::table('school_setup')->where(['client_id' => $user->client_id])->get()->toArray();
+                    $schools = DB::table('school_setup')->where(['client_id' => $user->client_id])
+                        ->get()->toArray();
                 }
-                // echo "<pre>";print_r($schools);exit;    
+                // echo "<pre>";print_r($schools);exit;
                 $client_sub_institute_id = '';
                 if (count($schools) > 0) {
                     $client_sub_institute_id = isset($schools[0]) ? $schools[0]->id : '';
                     $request->session()->put('syear', isset($schools[0]) ? $schools[0]->syear : '');
+                }
+                if (empty($client_sub_institute_id) && !empty($user['sub_institute_id'])) {
+                    $client_sub_institute_id = $user['sub_institute_id'];
+                    $fallbackSchool = DB::table('school_setup')->where('id', $user['sub_institute_id'])->first();
+                    if ($fallbackSchool) {
+                        $request->session()->put('syear', $fallbackSchool->syear ?? '');
+                    }
                 }
                 if ($user['is_admin'] == 2) {
                     $getTermId = DB::table('academic_year')->whereIn('sub_institute_id', [254, 195, 47, 72, 1])


### PR DESCRIPTION
apply fallback logic in both GoogleAuthController and authController to use the user's sub_institute_id when no schools are found via client_id, and set the correct session syear value from the fallback school if available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session initialization for multi-institute administrators by ensuring academic year data is properly populated when switching between institutes.
  * Added fallback mechanism to correctly populate institute and academic year information during authentication when standard data paths are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->