### PR TITLE
feat(api): implement leave and attendance management endpoints

### DIFF
--- a/app/Http/Controllers/Api/Attendance/AttendanceDashboardApiController.php
+++ b/app/Http/Controllers/Api/Attendance/AttendanceDashboardApiController.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace App\Http\Controllers\Api\Attendance;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Api\Attendance\Concerns\ResolvesAttendanceContext;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Attendance analytics for the HRIT dashboard / attendance tracking header.
+ *
+ * Legacy equivalents: Api\HRITDashboard\AttendanceApiController::weeklySummary
+ * (GET /api/attendance-weekly) and ::KPI (GET /api/KPI-HRITDashboard), which
+ * stay untouched and still serve every existing consumer. This controller
+ * keeps the same response contract and adds the optional employee_id filter so
+ * a single selected employee makes the denominator 1 and the series read as
+ * that person's own percentages.
+ */
+class AttendanceDashboardApiController extends Controller
+{
+    use ResolvesAttendanceContext;
+
+    /**
+     * GET /api/attendance/weekly-summary
+     */
+    public function weeklySummary(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $departmentId = $this->activeFilter($request->input('department_id'));
+        $employeeId = $this->activeFilter($request->input('employee_id'));
+
+        // DATE RANGE LOGIC
+        if ($request->filled('from_date') && $request->filled('to_date')) {
+            $start = Carbon::parse($request->input('from_date'));
+            $end   = Carbon::parse($request->input('to_date'));
+        } else {
+            // Default: previous week, Monday to Sunday.
+            $start = Carbon::now()->subWeek()->startOfWeek();
+            $end   = Carbon::now()->subWeek()->endOfWeek();
+        }
+
+        $attendanceQuery = DB::table('hrms_attendances')
+            ->join('tbluser', 'hrms_attendances.user_id', '=', 'tbluser.id')
+            ->where('hrms_attendances.sub_institute_id', $subInstituteId)
+            ->whereBetween('hrms_attendances.day', [
+                $start->format('Y-m-d'),
+                $end->format('Y-m-d'),
+            ]);
+
+        if ($departmentId) {
+            $attendanceQuery->where('tbluser.department_id', $departmentId);
+        }
+
+        if ($employeeId) {
+            $attendanceQuery->where('hrms_attendances.user_id', $employeeId);
+        }
+
+        $attendance = $attendanceQuery
+            ->select('hrms_attendances.*', 'tbluser.first_name', 'tbluser.monday_in_date', 'tbluser.department_id')
+            ->orderBy('hrms_attendances.day', 'ASC')
+            ->get();
+
+        $labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+        $present = [];
+        $absent  = [];
+        $late    = [];
+        $dailyPunchData = [];
+
+        $userQuery = DB::table('tbluser')
+            ->where('sub_institute_id', $subInstituteId)
+            ->where('status', 1)
+            ->whereNull('terminated_date');
+
+        if ($departmentId) {
+            $userQuery->where('department_id', $departmentId);
+        }
+
+        // A single selected employee makes the denominator 1, so the
+        // present/absent/late series read as that person's own percentages.
+        if ($employeeId) {
+            $userQuery->where('id', $employeeId);
+        }
+
+        $totalUsers = $userQuery->count();
+
+        foreach ($labels as $index => $dayName) {
+            $dayDate = $start->copy()->addDays($index)->format('Y-m-d');
+            $dayRecords = $attendance->where('day', $dayDate);
+
+            // Present is when both entries exist.
+            $presentCount = $dayRecords
+                ->whereNotNull('punchin_time')
+                ->whereNotNull('punchout_time')
+                ->count();
+
+            $lateCount = $dayRecords->filter(function ($rec) {
+                if ($rec->punchin_time && $rec->monday_in_date) {
+                    $punch = Carbon::parse($rec->punchin_time)->format('H:i:s');
+
+                    return $punch > $rec->monday_in_date;
+                }
+
+                return false;
+            })->count();
+
+            $absentCount = $totalUsers - $presentCount;
+
+            $punchTimes = [];
+            foreach ($dayRecords as $rec) {
+                if ($rec->punchin_time && $rec->punchout_time) {
+                    $punchTimes[] = [
+                        'employee_id' => $rec->user_id,
+                        'day'         => $rec->day,
+                        'type'        => 'present',
+                        'time'        => $rec->punchin_time,
+                    ];
+                } elseif (!$rec->punchin_time) {
+                    $punchTimes[] = [
+                        'employee_id' => $rec->user_id,
+                        'day'         => $rec->day,
+                        'type'        => 'absent',
+                        'time'        => null,
+                    ];
+                } else {
+                    $punchTimes[] = [
+                        'employee_id' => $rec->user_id,
+                        'day'         => $rec->day,
+                        'type'        => 'incomplete',
+                        'time'        => $rec->punchin_time,
+                    ];
+                }
+            }
+
+            $present[] = $totalUsers ? round(($presentCount / $totalUsers) * 100, 2) : 0;
+            $absent[]  = $totalUsers ? round(($absentCount / $totalUsers) * 100, 2) : 0;
+            $late[]    = $totalUsers ? round(($lateCount / $totalUsers) * 100, 2) : 0;
+
+            $dailyPunchData[$dayName] = $punchTimes;
+        }
+
+        return response()->json([
+            'date_range' => [
+                'start' => $start->format('Y-m-d'),
+                'end'   => $end->format('Y-m-d'),
+            ],
+            'department_filter' => $departmentId ?? 'All',
+            'employee_filter'   => $employeeId ?? 'All',
+            'labels'      => $labels,
+            'present'     => $present,
+            'absent'      => $absent,
+            'late'        => $late,
+            'punch_times' => $dailyPunchData,
+        ]);
+    }
+
+    /**
+     * GET /api/attendance/kpi
+     */
+    public function kpi(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $departmentId = $this->activeFilter($request->input('department_id'));
+        $employeeId = $this->activeFilter($request->input('employee_id'));
+
+        $today = Carbon::today()->format('Y-m-d');
+
+        $userQuery = DB::table('tbluser')
+            ->where('sub_institute_id', $subInstituteId);
+
+        if ($departmentId) {
+            $userQuery->where('department_id', $departmentId);
+        }
+
+        if ($employeeId) {
+            $userQuery->where('id', $employeeId);
+        }
+
+        $totalUsers = $userQuery->count();
+
+        $attendanceQuery = DB::table('hrms_attendances')
+            ->join('tbluser', 'hrms_attendances.user_id', '=', 'tbluser.id')
+            ->where('hrms_attendances.sub_institute_id', $subInstituteId)
+            ->where('hrms_attendances.day', $today)
+            ->where('hrms_attendances.status', 1);
+
+        if ($departmentId) {
+            $attendanceQuery->where('tbluser.department_id', $departmentId);
+        }
+
+        if ($employeeId) {
+            $attendanceQuery->where('hrms_attendances.user_id', $employeeId);
+        }
+
+        $presentCount = $attendanceQuery
+            ->distinct()
+            ->count('hrms_attendances.user_id');
+
+        $presentPercentage = $totalUsers
+            ? round(($presentCount / $totalUsers) * 100, 1)
+            : 0;
+
+        // LEAVE UTILIZATION over the April-March leave year.
+        $currentYear = Carbon::now()->year;
+        $startDate   = $currentYear . '-04-01';
+        $endDate     = ($currentYear + 1) . '-03-31';
+
+        $leaveQuery = DB::table('hrms_emp_leaves')
+            ->join('tbluser', 'hrms_emp_leaves.user_id', '=', 'tbluser.id')
+            ->where('hrms_emp_leaves.sub_institute_id', $subInstituteId)
+            ->where('hrms_emp_leaves.status', 'approved')
+            ->where('hrms_emp_leaves.from_date', '>=', $startDate)
+            ->where('hrms_emp_leaves.to_date', '<=', $endDate);
+
+        if ($departmentId) {
+            $leaveQuery->where('tbluser.department_id', $departmentId);
+        }
+
+        if ($employeeId) {
+            $leaveQuery->where('hrms_emp_leaves.user_id', $employeeId);
+        }
+
+        $totalLeaveDaysTaken = $leaveQuery
+            ->selectRaw('SUM((DATEDIFF(to_date, from_date) + 1) * day_type) as total_days')
+            ->value('total_days') ?? 0;
+
+        // ASSUMING 30 LEAVE DAYS PER EMPLOYEE PER YEAR
+        $totalAllocatedDays = $totalUsers * 30;
+
+        $leaveUtilization = $totalAllocatedDays
+            ? round(($totalLeaveDaysTaken / $totalAllocatedDays) * 100, 1)
+            : 0;
+
+        return response()->json([
+            'present_today'     => $presentPercentage . '%',
+            'leave_utilization' => $leaveUtilization . '%',
+            'active_employees'  => $totalUsers,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Attendance/AttendanceReportApiController.php
+++ b/app/Http/Controllers/Api/Attendance/AttendanceReportApiController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Api\Attendance;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Api\Attendance\Concerns\ResolvesAttendanceContext;
+use App\Models\HRMS\hrmsDepartmentModel;
+use App\Models\user\tbluserModel;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+/**
+ * Lookup endpoints for the Attendance Reports screen.
+ *
+ * The legacy equivalents are HrmsController::hrmsAttendanceReportIndex and
+ * HrmsController::getEmployeeLists on the `hrms-attendance-report` /
+ * `get-employees-list` web routes, which stay as they are for the Blade
+ * screens. This API variant scopes the department dropdown to the caller's
+ * sub_institute and treats an absent / "all" / 0 department as "every active
+ * employee of the institute" instead of returning an empty list.
+ */
+class AttendanceReportApiController extends Controller
+{
+    use ResolvesAttendanceContext;
+
+    /**
+     * GET /api/attendance/report-filters
+     *
+     * Department dropdown plus the default date range for the report screen.
+     */
+    public function filters(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+
+        // Scope the dropdown to the caller's institute, otherwise it offers
+        // departments that have no employees in this sub_institute.
+        $departments = hrmsDepartmentModel::where('status', true)
+            ->where('sub_institute_id', $subInstituteId)
+            ->orderBy('department')
+            ->pluck('department', 'id');
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Success to Find Data',
+            'employee_id' => $request->get('employee_id'),
+            'department_id' => $request->get('department_id'),
+            'from_date_formatted' => Carbon::now()->format('Y-m-d'),
+            'to_date_formatted' => Carbon::now()->format('Y-m-d'),
+            'departments' => $departments,
+        ]);
+    }
+
+    /**
+     * GET /api/attendance/employees
+     *
+     * Active employees of the institute, optionally narrowed to a department.
+     */
+    public function employees(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $departmentId = $this->activeFilter($request->input('department_id'));
+        $employeeId = $request->get('employee_id');
+
+        $employees = tbluserModel::where('sub_institute_id', $subInstituteId)
+            ->where('status', 1)
+            ->when($departmentId, function ($query) use ($departmentId) {
+                $query->where('department_id', $departmentId);
+            })
+            ->orderBy('first_name')
+            ->orderBy('last_name')
+            ->get(['id', 'employee_no', 'first_name', 'middle_name', 'last_name', 'department_id'])
+            ->toArray();
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Success to Find Data',
+            'employees' => $employees,
+            'department_id' => $request->input('department_id'),
+            'employee_id' => $employeeId,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Attendance/AttendanceTrackingApiController.php
+++ b/app/Http/Controllers/Api/Attendance/AttendanceTrackingApiController.php
@@ -1,0 +1,454 @@
+<?php
+
+namespace App\Http\Controllers\Api\Attendance;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Api\Attendance\Concerns\ResolvesAttendanceContext;
+use App\Models\HRMS\HrmsAttendance;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Attendance self service API backing the Next.js Attendance Tracking screen.
+ *
+ * The legacy flow is HrmsController::hrmsAttendance (formType=MyAttendance),
+ * ::hrmsAttendanceInTimeStore and ::hrmsAttendanceOutTimeStore on the stateful
+ * `hrms-attendance*` web routes. Those keep working unchanged for the Blade
+ * screens and the mobile app; this controller is the stateless API variant and
+ * adds the calendar window, the resolved per day status (present / late /
+ * leave / absent / holiday / week-off) and JSON punch responses.
+ */
+class AttendanceTrackingApiController extends Controller
+{
+    use ResolvesAttendanceContext;
+
+    private const WEEKDAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+    /**
+     * GET /api/attendance/my-attendance
+     *
+     * Punch rows for the requested window plus a day by day calendar and the
+     * period totals. Defaults to the running month when no range is given.
+     */
+    public function myAttendance(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $userId = $context['user_id'];
+
+        if (!$userId) {
+            return response()->json(['status' => 0, 'message' => 'user_id is required'], 400);
+        }
+
+        $today = Carbon::now()->startOfDay();
+
+        // Calendar window. Falls back to the current month so callers that omit
+        // the range keep getting the running month.
+        $fromDate = $request->filled('from_date')
+            ? Carbon::parse($request->input('from_date'))->startOfDay()
+            : $today->copy()->startOfMonth();
+        $toDate = $request->filled('to_date')
+            ? Carbon::parse($request->input('to_date'))->startOfDay()
+            : $today->copy()->endOfMonth();
+
+        if ($toDate->lt($fromDate)) {
+            [$fromDate, $toDate] = [$toDate, $fromDate];
+        }
+
+        $rangeStart = $fromDate->format('Y-m-d');
+        $rangeEnd = $toDate->format('Y-m-d');
+
+        $employee = DB::table('tbluser')->where('id', $userId)->first();
+        $leaveDates = $this->leaveDates($userId, $subInstituteId, $rangeStart, $rangeEnd);
+        $holidayDates = $this->holidayDates($subInstituteId, $employee->department_id ?? null, $rangeStart, $rangeEnd);
+
+        $attendanceData = HrmsAttendance::with([
+            'getUser' => function ($query) {
+                $query->select(
+                    'tbluser.id',
+                    DB::raw('CONCAT_WS(" ", COALESCE(first_name,"-"), COALESCE(middle_name,"-"), COALESCE(last_name,"-")) as employee_name')
+                );
+            },
+            'getDepartment' => function ($query) {
+                $query->select(
+                    'hrms_departments.id',
+                    'department'
+                );
+            },
+        ])
+            ->where([['user_id', $userId], ['sub_institute_id', $subInstituteId], ['status', 1]])
+            ->whereNull('deleted_at')
+            ->whereBetween('day', [$rangeStart, $rangeEnd])
+            ->orderBy('day')
+            ->get()
+            ->map(function ($item) use ($employee) {
+                $item->employee_name = $item->getUser ? $item->getUser->employee_name : '';
+                $item->department = $item->getDepartment ? $item->getDepartment->department : '';
+                unset($item->getUser);
+                unset($item->getDepartment);
+                $item->attendance_status = $this->punchStatus($item, $employee);
+
+                return $item;
+            });
+
+        $punchedDays = [];
+        foreach ($attendanceData as $entry) {
+            $punchedDays[Carbon::parse($entry->day)->format('Y-m-d')] = $entry;
+        }
+
+        // A day is scheduled from the employee's weekday roster. When no roster
+        // is configured, fall back to "every day except Sunday", which is what
+        // the department-wise report assumes.
+        $hasRoster = false;
+        foreach (self::WEEKDAY_NAMES as $weekdayName) {
+            if (!empty($employee->{$weekdayName})) {
+                $hasRoster = true;
+                break;
+            }
+        }
+
+        $calendar = [];
+        $totalDays = $presentDays = $lateDays = $leaveDays = $absentDays = $holidayCount = $workingDays = 0;
+
+        for ($date = $fromDate->copy(); $date->lte($toDate); $date->addDay()) {
+            $totalDays++;
+            $key = $date->format('Y-m-d');
+            $dayName = strtolower($date->format('l'));
+            $isWorkingDay = $hasRoster ? !empty($employee->{$dayName}) : !$date->isSunday();
+            $isHoliday = isset($holidayDates[$key]);
+            $status = null;
+
+            if (isset($punchedDays[$key])) {
+                $status = $punchedDays[$key]->attendance_status;
+            } elseif (isset($leaveDates[$key])) {
+                $status = 'leave';
+            } elseif ($isWorkingDay && !$isHoliday && $date->lt($today)) {
+                // Only elapsed scheduled days can be marked absent. Today is
+                // still open, and future days, holidays and week-offs stay
+                // unmarked.
+                $status = 'absent';
+            }
+
+            if ($isWorkingDay && !$isHoliday) {
+                $workingDays++;
+            }
+            if ($isHoliday) {
+                $holidayCount++;
+            }
+
+            switch ($status) {
+                case 'present':
+                    $presentDays++;
+                    break;
+                case 'late':
+                    $lateDays++;
+                    break;
+                case 'leave':
+                    $leaveDays++;
+                    break;
+                case 'absent':
+                    $absentDays++;
+                    break;
+            }
+
+            $calendar[] = [
+                'date' => $key,
+                'day_name' => $date->format('l'),
+                'status' => $status,
+                'is_working_day' => $isWorkingDay,
+                'is_holiday' => $isHoliday,
+                'holiday_name' => $isHoliday ? $holidayDates[$key] : null,
+                'leave_type' => $leaveDates[$key]['leave_type'] ?? null,
+                'day_type' => $leaveDates[$key]['day_type'] ?? null,
+                'punchin_time' => isset($punchedDays[$key]) ? $punchedDays[$key]->punchin_time : null,
+                'punchout_time' => isset($punchedDays[$key]) ? $punchedDays[$key]->punchout_time : null,
+                'timestamp_diff' => isset($punchedDays[$key]) ? $punchedDays[$key]->timestamp_diff : null,
+            ];
+        }
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Success to Find Data',
+            'fromDate' => $rangeStart,
+            'toDate' => $rangeEnd,
+            'daysInMonth' => $totalDays,
+            'workingDays' => $workingDays,
+            'holidays' => $holidayCount,
+            'presentDays' => $presentDays,
+            'lateDays' => $lateDays,
+            'leaveDays' => $leaveDays,
+            'absentDays' => $absentDays,
+            'percentege' => $workingDays > 0
+                ? round((($presentDays + $lateDays) / $workingDays) * 100, 2)
+                : 0,
+            'calendar' => $calendar,
+            'attendanceData' => $attendanceData,
+        ]);
+    }
+
+    /**
+     * POST /api/attendance/punch-in
+     *
+     * Re-punching the same day resets the out side of the row so the day does
+     * not keep a stale punch out / duration from the previous punch.
+     */
+    public function punchIn(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'employee' => 'required',
+            'indate'   => 'required',
+            'intime'   => 'required',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first()], 422);
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $formattedDate = Carbon::parse($request->input('indate'))->format('Y-m-d');
+
+        $record = HrmsAttendance::where('user_id', $request->input('employee'))
+            ->where('sub_institute_id', $subInstituteId)
+            ->whereDate('day', $formattedDate)
+            ->first();
+
+        if ($record) {
+            $record->punchin_time = Carbon::parse($formattedDate . ' ' . $request->input('intime'))->format('Y-m-d H:i:s');
+            $record->punchout_time = null;
+            $record->timestamp_diff = null;
+            $record->ipaddress_in = $request->ip();
+            $record->ipaddress_out = null;
+            $record->in_note = 1;
+            $record->out_note = 0;
+            $record->save();
+        } else {
+            $record = new HrmsAttendance();
+            $record->user_id = $request->input('employee');
+            $record->punchin_time = Carbon::parse($formattedDate . ' ' . $request->input('intime'))->format('Y-m-d H:i:s');
+            $record->day = $formattedDate;
+            $record->in_note = 1;
+            $record->ipaddress_in = $request->ip();
+            $record->sub_institute_id = $subInstituteId;
+            $record->save();
+        }
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Attendance punch in saved successfully',
+            'attendanceData' => $record,
+        ]);
+    }
+
+    /**
+     * POST /api/attendance/punch-out
+     */
+    public function punchOut(Request $request)
+    {
+        $context = $this->attendanceContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'employee' => 'required',
+            'outdate'  => 'required',
+            'outtime'  => 'nullable',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first()], 422);
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $dateOnly = Carbon::parse($request->input('outdate'))->format('Y-m-d');
+        $punchoutTime = $request->input('outtime')
+            ? Carbon::parse($request->input('outdate') . ' ' . $request->input('outtime'))
+            : null;
+
+        // Either the open row for the day, or the latest one when a time was sent.
+        $attendance = HrmsAttendance::where('user_id', $request->input('employee'))
+            ->where('sub_institute_id', $subInstituteId)
+            ->where('day', $dateOnly)
+            ->when(!$punchoutTime, function ($query) {
+                return $query->whereNull('punchout_time');
+            }, function ($query) {
+                return $query->orderBy('id', 'desc');
+            })
+            ->first();
+
+        if ($attendance) {
+            $attendance->punchout_time = $punchoutTime?->format('Y-m-d H:i:s');
+            $attendance->ipaddress_out = $request->ip();
+            $attendance->out_note = 1;
+
+            if ($punchoutTime && $attendance->punchin_time) {
+                $attendance->timestamp_diff = $this->durationBetween(
+                    Carbon::parse($attendance->punchin_time),
+                    $punchoutTime
+                );
+            }
+
+            $attendance->save();
+        } else {
+            // Already punched out before - overwrite with the current time.
+            $existingRecord = HrmsAttendance::where([
+                ['user_id', $request->input('employee')],
+                ['sub_institute_id', $subInstituteId],
+                ['day', $dateOnly],
+            ])->orderBy('id', 'desc')->first();
+
+            if ($existingRecord && $existingRecord->punchin_time) {
+                $now = Carbon::now();
+
+                $existingRecord->punchout_time = ($request->input('outtime') == '') ? null : $now->format('Y-m-d H:i:s');
+                $existingRecord->ipaddress_out = $request->ip();
+                $existingRecord->out_note = 1;
+                $existingRecord->timestamp_diff = $this->durationBetween(
+                    Carbon::parse($existingRecord->punchin_time),
+                    $now
+                );
+                $existingRecord->save();
+
+                $attendance = $existingRecord;
+            }
+        }
+
+        if (!$attendance) {
+            return response()->json([
+                'status' => 0,
+                'message' => 'No punch in record found for this employee and date',
+            ], 404);
+        }
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Attendance punch out saved successfully',
+            'attendanceData' => $attendance,
+        ]);
+    }
+
+    /** Absolute difference between two punches as HH:MM. */
+    private function durationBetween(Carbon $punchIn, Carbon $punchOut): string
+    {
+        $min = (int) $punchOut->diffInMinutes($punchIn, true);
+
+        return sprintf('%02d:%02d', floor($min / 60), $min % 60);
+    }
+
+    /**
+     * Approved leave days for an employee, keyed by Y-m-d.
+     */
+    private function leaveDates($userId, $subInstituteId, $rangeStart, $rangeEnd): array
+    {
+        $leaves = DB::table('hrms_emp_leaves as hel')
+            ->leftJoin('hrms_leave_types as hlt', 'hlt.id', '=', 'hel.leave_type_id')
+            ->select('hel.from_date', 'hel.to_date', 'hel.day_type', 'hlt.leave_type')
+            ->where('hel.user_id', $userId)
+            ->where('hel.sub_institute_id', $subInstituteId)
+            ->where('hel.status', 'approved')
+            ->whereNull('hel.deleted_at')
+            ->where('hel.from_date', '<=', $rangeEnd)
+            ->where('hel.to_date', '>=', $rangeStart)
+            ->get();
+
+        $leaveDates = [];
+
+        foreach ($leaves as $leave) {
+            if (empty($leave->from_date)) {
+                continue;
+            }
+
+            $start = Carbon::parse($leave->from_date)->startOfDay();
+            $end = Carbon::parse($leave->to_date ?: $leave->from_date)->startOfDay();
+
+            for ($date = $start->copy(); $date->lte($end); $date->addDay()) {
+                $leaveDates[$date->format('Y-m-d')] = [
+                    'leave_type' => $leave->leave_type ?? null,
+                    'day_type' => $leave->day_type ?? null,
+                ];
+            }
+        }
+
+        return $leaveDates;
+    }
+
+    /**
+     * Holiday days that apply to a department, keyed by Y-m-d => holiday name.
+     */
+    private function holidayDates($subInstituteId, $departmentId, $rangeStart, $rangeEnd): array
+    {
+        $holidays = DB::table('hrms_holidays')
+            ->where('sub_institute_id', $subInstituteId)
+            ->whereNull('deleted_at')
+            ->where('from_date', '<=', $rangeEnd)
+            ->where('to_date', '>=', $rangeStart)
+            ->when($departmentId, function ($q) use ($departmentId) {
+                // A holiday with no department applies institute-wide.
+                $q->where(function ($q) use ($departmentId) {
+                    $q->whereNull('department')
+                        ->orWhere('department', '')
+                        ->orWhere('department', '0')
+                        ->orWhereRaw('FIND_IN_SET(?, department)', [$departmentId]);
+                });
+            })
+            ->get();
+
+        $holidayDates = [];
+
+        foreach ($holidays as $holiday) {
+            if (empty($holiday->from_date)) {
+                continue;
+            }
+
+            $start = Carbon::parse($holiday->from_date)->startOfDay();
+            $end = Carbon::parse($holiday->to_date ?: $holiday->from_date)->startOfDay();
+
+            for ($date = $start->copy(); $date->lte($end); $date->addDay()) {
+                $holidayDates[$date->format('Y-m-d')] = $holiday->holiday_name ?: 'Holiday';
+            }
+        }
+
+        return $holidayDates;
+    }
+
+    /**
+     * Resolve a punched day as "late" or "present" against the employee's
+     * rostered start time for that weekday.
+     */
+    private function punchStatus($attendance, $employee): ?string
+    {
+        if (empty($attendance->punchin_time)) {
+            return null;
+        }
+
+        $dayName = strtolower(Carbon::parse($attendance->day)->format('l'));
+        $shiftStart = $employee->{$dayName . '_in_date'} ?? null;
+
+        if (empty($shiftStart)) {
+            return 'present';
+        }
+
+        try {
+            $punchIn = Carbon::parse($attendance->punchin_time);
+            $expected = Carbon::parse($attendance->day . ' ' . Carbon::parse($shiftStart)->format('H:i:s'));
+        } catch (\Exception $e) {
+            return 'present';
+        }
+
+        return $punchIn->gt($expected) ? 'late' : 'present';
+    }
+}

--- a/app/Http/Controllers/Api/Attendance/Concerns/ResolvesAttendanceContext.php
+++ b/app/Http/Controllers/Api/Attendance/Concerns/ResolvesAttendanceContext.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api\Attendance\Concerns;
+
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Shared request context resolution for the Attendance Management API.
+ *
+ * The legacy attendance screens live on stateful web routes and read
+ * sub_institute_id / user_id out of the session. The endpoints under
+ * /api/attendance are stateless, so everything is resolved from the request
+ * and authenticated with a Sanctum personal access token passed as `token`,
+ * exactly like App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext.
+ */
+trait ResolvesAttendanceContext
+{
+    /**
+     * @return array{sub_institute_id:int, user_id:int|null, syear:string|null}|\Illuminate\Http\JsonResponse
+     */
+    protected function attendanceContext(Request $request)
+    {
+        $token = $request->input('token');
+
+        if (!$token) {
+            return response()->json(['status' => 0, 'message' => 'Token not provided'], 401);
+        }
+
+        if (!PersonalAccessToken::findToken($token)) {
+            return response()->json(['status' => 0, 'message' => 'Invalid token'], 401);
+        }
+
+        $subInstituteId = $request->input('sub_institute_id') ?? $request->header('sub_institute_id');
+
+        if (!$subInstituteId || !is_numeric($subInstituteId)) {
+            return response()->json(['status' => 0, 'message' => 'sub_institute_id is required'], 400);
+        }
+
+        return [
+            'sub_institute_id' => (int) $subInstituteId,
+            'user_id'          => is_numeric($request->input('user_id')) ? (int) $request->input('user_id') : null,
+            'syear'            => $request->input('syear'),
+        ];
+    }
+
+    /** Treat 'all', '0' and empty string as "no filter". */
+    protected function activeFilter($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            $value = array_values(array_filter($value, fn ($item) => $item !== null && $item !== '' && $item !== '0' && $item !== 'all'));
+
+            return empty($value) ? null : (string) reset($value);
+        }
+
+        $value = trim((string) $value);
+
+        return ($value === '' || $value === '0' || strtolower($value) === 'all') ? null : $value;
+    }
+}

--- a/app/Http/Controllers/Api/Leave/Concerns/ResolvesLeaveContext.php
+++ b/app/Http/Controllers/Api/Leave/Concerns/ResolvesLeaveContext.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave\Concerns;
+
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Shared request context resolution for the Leave Management API.
+ *
+ * Every endpoint under /api/leave is token authenticated (Sanctum personal
+ * access token passed as `token`), and every query is scoped by
+ * sub_institute_id + the April-March leave year.
+ */
+trait ResolvesLeaveContext
+{
+    /**
+     * @return array{sub_institute_id:int, user_id:int|null, year:int, from:string, to:string}|\Illuminate\Http\JsonResponse
+     */
+    protected function leaveContext(Request $request)
+    {
+        $token = $request->input('token');
+
+        if (!$token) {
+            return response()->json(['status' => 0, 'message' => 'Token not provided'], 401);
+        }
+
+        if (!PersonalAccessToken::findToken($token)) {
+            return response()->json(['status' => 0, 'message' => 'Invalid token'], 401);
+        }
+
+        $subInstituteId = $request->input('sub_institute_id') ?? $request->header('sub_institute_id');
+
+        if (!$subInstituteId || !is_numeric($subInstituteId)) {
+            return response()->json(['status' => 0, 'message' => 'sub_institute_id is required'], 400);
+        }
+
+        $year = $this->normaliseLeaveYear($request->input('syear') ?? $request->input('year'));
+
+        return [
+            'sub_institute_id' => (int) $subInstituteId,
+            'user_id'          => is_numeric($request->input('user_id')) ? (int) $request->input('user_id') : null,
+            'year'             => $year,
+            'from'             => $year . '-04-01',
+            'to'               => ($year + 1) . '-03-31',
+        ];
+    }
+
+    /**
+     * The frontend stores syear in several shapes ("2024", "2024-25", "2024-2025").
+     * Everything downstream builds date strings from it, so collapse to the
+     * 4 digit opening year of the April-March window.
+     */
+    protected function normaliseLeaveYear($value): int
+    {
+        if (is_numeric($value) && (int) $value > 1900 && (int) $value < 2200) {
+            return (int) $value;
+        }
+
+        if (is_string($value) && preg_match('/(\d{4})/', $value, $matches)) {
+            return (int) $matches[1];
+        }
+
+        // Before April the current leave year is still the previous calendar year.
+        return (int) date('n') >= 4 ? (int) date('Y') : (int) date('Y') - 1;
+    }
+
+    /** Treat 'all', '0' and empty string as "no filter". */
+    protected function activeFilter($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            $value = array_values(array_filter($value, fn ($item) => $item !== null && $item !== '' && $item !== '0' && $item !== 'all'));
+            return empty($value) ? null : implode(',', $value);
+        }
+
+        $value = trim((string) $value);
+
+        return ($value === '' || $value === '0' || strtolower($value) === 'all') ? null : $value;
+    }
+
+    /** Normalise a repeatable filter into a clean list. */
+    protected function filterList($value): array
+    {
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        if (!is_array($value)) {
+            $value = explode(',', (string) $value);
+        }
+
+        return array_values(array_filter(array_map('trim', $value), function ($item) {
+            return $item !== '' && $item !== '0' && strtolower($item) !== 'all';
+        }));
+    }
+}

--- a/app/Http/Controllers/Api/Leave/HolidayApiController.php
+++ b/app/Http/Controllers/Api/Leave/HolidayApiController.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class HolidayApiController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    private const WEEKDAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+    /**
+     * GET /api/leave/holidays
+     */
+    public function index(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $calendarYear = $this->activeFilter($request->input('calendar_year'));
+        $departmentId = $this->activeFilter($request->input('department_id'));
+
+        $holidays = DB::table('hrms_holidays')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->when($calendarYear, fn ($q) => $q->whereYear('from_date', $calendarYear))
+            ->when($departmentId, fn ($q) => $q->whereRaw('FIND_IN_SET(?, department)', [$departmentId]))
+            ->orderBy('from_date')
+            ->get();
+
+        $departments = DB::table('hrms_departments')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->pluck('department', 'id');
+
+        $data = $holidays->map(function ($holiday) use ($departments) {
+            $ids = array_filter(explode(',', (string) $holiday->department));
+
+            return [
+                'id'              => (int) $holiday->id,
+                'holiday_name'    => $holiday->holiday_name,
+                'description'     => $holiday->description ?? null,
+                'from_date'       => $holiday->from_date,
+                'to_date'         => $holiday->to_date,
+                'day'             => $holiday->from_date ? Carbon::parse($holiday->from_date)->format('l') : null,
+                'applicable_year' => $holiday->from_date ? Carbon::parse($holiday->from_date)->format('Y') : null,
+                'day_type'        => $holiday->day_type,
+                'department_ids'  => array_values(array_map('intval', $ids)),
+                'department_names'=> array_values(array_filter(array_map(fn ($id) => $departments[$id] ?? null, $ids))),
+            ];
+        });
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Holidays fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * POST /api/leave/holidays
+     */
+    public function store(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validated = $this->validatePayload($request);
+        if (!is_array($validated)) {
+            return $validated;
+        }
+
+        $duplicate = DB::table('hrms_holidays')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('from_date', $validated['from_date'])
+            ->whereNull('deleted_at')
+            ->exists();
+
+        if ($duplicate) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'A holiday already exists on this date',
+                'errors'  => ['from_date' => ['A holiday already exists on this date']],
+            ], 422);
+        }
+
+        $id = DB::table('hrms_holidays')->insertGetId(array_merge($validated, [
+            'sub_institute_id' => $context['sub_institute_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+        ]));
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Holiday added successfully',
+            'data'    => ['id' => (int) $id],
+        ], 201);
+    }
+
+    /**
+     * PUT /api/leave/holidays/{id}
+     *
+     * HolidayController::update() was an empty stub and its store() upserted on
+     * (from_date, to_date, department), so renaming or moving a holiday was
+     * impossible. This is a real edit by primary key.
+     */
+    public function update(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $holiday = DB::table('hrms_holidays')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$holiday) {
+            return response()->json(['status' => 0, 'message' => 'Holiday not found'], 404);
+        }
+
+        $validated = $this->validatePayload($request);
+        if (!is_array($validated)) {
+            return $validated;
+        }
+
+        $duplicate = DB::table('hrms_holidays')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('from_date', $validated['from_date'])
+            ->where('id', '!=', $id)
+            ->whereNull('deleted_at')
+            ->exists();
+
+        if ($duplicate) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'Another holiday already exists on this date',
+                'errors'  => ['from_date' => ['Another holiday already exists on this date']],
+            ], 422);
+        }
+
+        DB::table('hrms_holidays')->where('id', $id)->update(array_merge($validated, [
+            'updated_at' => now(),
+            'updated_by' => $context['user_id'],
+        ]));
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Holiday updated successfully',
+            'data'    => ['id' => (int) $id],
+        ]);
+    }
+
+    /**
+     * DELETE /api/leave/holidays/{id}   ({id} accepts a comma separated list)
+     */
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $ids = array_values(array_filter(array_map('intval', explode(',', (string) $id))));
+
+        if (empty($ids)) {
+            return response()->json(['status' => 0, 'message' => 'No holiday id supplied'], 422);
+        }
+
+        $deleted = DB::table('hrms_holidays')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereIn('id', $ids)
+            ->whereNull('deleted_at')
+            ->update([
+                'deleted_at' => now(),
+                'deleted_by' => $context['user_id'],
+            ]);
+
+        if (!$deleted) {
+            return response()->json(['status' => 0, 'message' => 'Holiday not found'], 404);
+        }
+
+        return response()->json([
+            'status'        => 1,
+            'message'       => $deleted . ' holiday(s) deleted successfully',
+            'deleted_count' => $deleted,
+        ]);
+    }
+
+    /**
+     * GET /api/leave/weekdays
+     *
+     * The route GET holiday.weekdays -> HolidayController::getWeekdays has always
+     * been registered against a method that does not exist.
+     */
+    public function weekdays(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $saved = DB::table('hrms_weekdays')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->pluck('day_type', 'day');
+
+        $data = collect(self::WEEKDAYS)->map(fn ($day) => [
+            'day'      => $day,
+            'label'    => ucfirst($day),
+            'day_type' => $saved[$day] ?? 'full',
+        ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Weekdays fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * POST /api/leave/weekdays
+     */
+    public function storeWeekdays(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rules = [];
+        foreach (self::WEEKDAYS as $day) {
+            $rules[$day] = 'required|in:full,half,weekend';
+        }
+
+        $validator = Validator::make($request->all(), $rules);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        DB::transaction(function () use ($request, $context) {
+            foreach (self::WEEKDAYS as $day) {
+                $existing = DB::table('hrms_weekdays')
+                    ->where('sub_institute_id', $context['sub_institute_id'])
+                    ->where('day', $day)
+                    ->whereNull('deleted_at')
+                    ->first();
+
+                if ($existing) {
+                    DB::table('hrms_weekdays')->where('id', $existing->id)->update([
+                        'day_type'   => $request->input($day),
+                        'updated_at' => now(),
+                        'updated_by' => $context['user_id'],
+                    ]);
+                } else {
+                    DB::table('hrms_weekdays')->insert([
+                        'day'              => $day,
+                        'day_type'         => $request->input($day),
+                        'sub_institute_id' => $context['sub_institute_id'],
+                        'created_at'       => now(),
+                        'created_by'       => $context['user_id'],
+                    ]);
+                }
+            }
+        });
+
+        return response()->json(['status' => 1, 'message' => 'Weekly off pattern saved successfully']);
+    }
+
+    /**
+     * @return array<string, mixed>|\Illuminate\Http\JsonResponse
+     */
+    private function validatePayload(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'holiday_name'  => 'required|string|max:191',
+            'description'   => 'nullable|string|max:500',
+            'from_date'     => 'required|date',
+            'to_date'       => 'nullable|date|after_or_equal:from_date',
+            'day_type'      => 'nullable|in:full,half',
+            'department'    => 'nullable|array',
+            'department.*'  => 'integer',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $fromDate = Carbon::parse($request->input('from_date'))->toDateString();
+        $toDate   = $request->filled('to_date')
+            ? Carbon::parse($request->input('to_date'))->toDateString()
+            : $fromDate;
+
+        $departments = array_values(array_filter((array) $request->input('department', [])));
+
+        return [
+            'holiday_name' => trim($request->input('holiday_name')),
+            'description'  => $request->input('description'),
+            'from_date'    => $fromDate,
+            'to_date'      => $toDate,
+            // Empty department list means the holiday applies institute-wide.
+            'department'   => empty($departments) ? '' : implode(',', $departments),
+            'day_type'     => $request->input('day_type', 'full'),
+            'deleted_at'   => null,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveDashboardController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveDashboardController.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use App\Services\Leave\LeaveAnalyticsService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LeaveDashboardController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    public function __construct(private LeaveAnalyticsService $analytics)
+    {
+    }
+
+    /**
+     * GET /api/leave/dashboard
+     * KPI cards + recent activity for the Leave Dashboard screen.
+     */
+    public function index(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $departmentId = $this->activeFilter($request->input('department_id'));
+        $today = Carbon::today()->toDateString();
+
+        $counts = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->selectRaw("
+                COUNT(*) AS total_requests,
+                SUM(CASE WHEN hel.status = 'pending' THEN 1 ELSE 0 END) AS pending_requests,
+                SUM(CASE WHEN hel.status IN ('approved','approved_lwp') THEN 1 ELSE 0 END) AS approved_requests,
+                SUM(CASE WHEN hel.status = 'rejected' THEN 1 ELSE 0 END) AS rejected_requests,
+                SUM(CASE WHEN hel.status = 'cancelled' THEN 1 ELSE 0 END) AS cancelled_requests
+            ")
+            ->first();
+
+        $onLeaveToday = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->whereIn('hel.status', ['approved', 'approved_lwp'])
+            ->where('hel.from_date', '<=', $today)
+            ->where('hel.to_date', '>=', $today)
+            ->distinct()
+            ->count('hel.user_id');
+
+        $availableBalance = 0.0;
+        if ($context['user_id']) {
+            $balances = $this->analytics->balancesForEmployee(
+                $context['sub_institute_id'],
+                $context['year'],
+                $context['user_id']
+            );
+            $availableBalance = $balances['overall']['remaining'];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave dashboard fetched successfully',
+            'year'    => $context['year'],
+            'data'    => [
+                'total_requests'    => (int) ($counts->total_requests ?? 0),
+                'pending_requests'  => (int) ($counts->pending_requests ?? 0),
+                'approved_requests' => (int) ($counts->approved_requests ?? 0),
+                'rejected_requests' => (int) ($counts->rejected_requests ?? 0),
+                'cancelled_requests'=> (int) ($counts->cancelled_requests ?? 0),
+                'on_leave_today'    => (int) $onLeaveToday,
+                'available_balance' => $availableBalance,
+                'recent_activity'   => $this->recentActivity($context, $departmentId),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/leave/trend
+     * Requests / approved / rejected for each month of the April-March leave year.
+     */
+    public function trend(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $departmentId = $this->activeFilter($request->input('department_id'));
+
+        $rows = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->selectRaw("
+                DATE_FORMAT(hel.from_date, '%Y-%m') AS period,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN hel.status IN ('approved','approved_lwp') THEN 1 ELSE 0 END) AS approved,
+                SUM(CASE WHEN hel.status = 'rejected' THEN 1 ELSE 0 END) AS rejected
+            ")
+            ->groupBy('period')
+            ->get()
+            ->keyBy('period');
+
+        // Always emit all 12 months of the leave year so the chart never has gaps.
+        $data = [];
+        $cursor = Carbon::createFromFormat('Y-m-d', $context['from']);
+
+        for ($i = 0; $i < 12; $i++) {
+            $period = $cursor->format('Y-m');
+            $row = $rows->get($period);
+
+            $data[] = [
+                'period'   => $period,
+                'month'    => $cursor->format('M'),
+                'requests' => (int) ($row->requests ?? 0),
+                'approved' => (int) ($row->approved ?? 0),
+                'rejected' => (int) ($row->rejected ?? 0),
+            ];
+
+            $cursor->addMonth();
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave trend fetched successfully',
+            'year'    => $context['year'],
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * GET /api/leave/department-summary
+     */
+    public function departmentSummary(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->selectRaw("
+                COALESCE(hd.department, 'Unassigned') AS department,
+                COALESCE(hd.id, 0) AS department_id,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN hel.status IN ('approved','approved_lwp') THEN 1 ELSE 0 END) AS approved,
+                SUM(CASE WHEN hel.status = 'rejected' THEN 1 ELSE 0 END) AS rejected,
+                SUM(CASE WHEN hel.status = 'pending' THEN 1 ELSE 0 END) AS pending
+            ")
+            ->groupBy('hd.id', 'hd.department')
+            ->orderByDesc('requests')
+            ->get()
+            ->map(fn ($row) => [
+                'department_id' => (int) $row->department_id,
+                'department'    => $row->department,
+                'requests'      => (int) $row->requests,
+                'approved'      => (int) $row->approved,
+                'rejected'      => (int) $row->rejected,
+                'pending'       => (int) $row->pending,
+            ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Department summary fetched successfully',
+            'year'    => $context['year'],
+            'data'    => $rows,
+        ]);
+    }
+
+    /**
+     * GET /api/leave/type-distribution
+     * Replaces /api/leave-distribution, whose join compared hrms_leave_types.leave_type_id
+     * (an "LTY0xx" string) against hrms_emp_leaves.leave_type_id (an integer FK) and so
+     * never matched a row.
+     */
+    public function typeDistribution(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $departmentId = $this->activeFilter($request->input('department_id'));
+
+        $rows = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->selectRaw("
+                COALESCE(hlt.leave_type, 'Unassigned') AS leave_type,
+                COALESCE(hlt.id, 0) AS leave_type_id,
+                COUNT(*) AS leave_count,
+                SUM(CASE WHEN hel.day_type = '0.5' THEN 1 ELSE 0 END) AS half_day_count,
+                SUM(CASE WHEN hel.day_type <> '0.5' OR hel.day_type IS NULL THEN 1 ELSE 0 END) AS full_day_count
+            ")
+            ->groupBy('hlt.id', 'hlt.leave_type')
+            ->orderByDesc('leave_count')
+            ->get()
+            ->map(fn ($row) => [
+                'leave_type_id'  => (int) $row->leave_type_id,
+                'leave_type'     => $row->leave_type,
+                'leave_count'    => (int) $row->leave_count,
+                'full_day_count' => (int) $row->full_day_count,
+                'half_day_count' => (int) $row->half_day_count,
+            ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave distribution fetched successfully',
+            'year'    => $context['year'],
+            'data'    => $rows,
+        ]);
+    }
+
+    /**
+     * GET /api/leave/holidays/upcoming
+     */
+    public function upcomingHolidays(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $limit = min(max((int) $request->input('limit', 5), 1), 50);
+
+        $holidays = DB::table('hrms_holidays')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->whereDate('to_date', '>=', Carbon::today()->toDateString())
+            ->orderBy('from_date')
+            ->limit($limit)
+            ->get()
+            ->map(fn ($holiday) => [
+                'id'           => (int) $holiday->id,
+                'name'         => $holiday->holiday_name,
+                'from_date'    => $holiday->from_date,
+                'to_date'      => $holiday->to_date,
+                'day'          => $holiday->from_date ? Carbon::parse($holiday->from_date)->format('l') : null,
+                'day_type'     => $holiday->day_type,
+                'department'   => $holiday->department,
+            ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Upcoming holidays fetched successfully',
+            'data'    => $holidays,
+        ]);
+    }
+
+    /**
+     * Activity feed derived from the leave rows themselves - a request is an
+     * "application" until it is decided, at which point the decision timestamp wins.
+     */
+    private function recentActivity(array $context, ?string $departmentId): array
+    {
+        $rows = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->selectRaw("
+                hel.id,
+                hel.status,
+                hel.from_date,
+                hel.to_date,
+                hel.comment,
+                hel.approved_by,
+                hel.created_at,
+                hel.updated_at,
+                hel.hod_comment_date,
+                hel.hr_remark_date,
+                COALESCE(hlt.leave_type, 'Leave') AS leave_type,
+                CONCAT_WS(' ', u.first_name, u.last_name) AS employee_name,
+                GREATEST(COALESCE(hel.updated_at, hel.created_at), COALESCE(hel.created_at, hel.updated_at)) AS activity_at
+            ")
+            ->orderByDesc('activity_at')
+            ->orderByDesc('hel.id')
+            ->limit(10)
+            ->get();
+
+        return $rows->map(function ($row) {
+            $type = match ($row->status) {
+                'approved', 'approved_lwp' => 'approval',
+                'rejected'                 => 'rejection',
+                'cancelled'                => 'cancellation',
+                default                    => 'application',
+            };
+
+            $title = match ($type) {
+                'approval'     => trim($row->employee_name) . "'s " . $row->leave_type . ' approved',
+                'rejection'    => trim($row->employee_name) . "'s " . $row->leave_type . ' rejected',
+                'cancellation' => trim($row->employee_name) . "'s " . $row->leave_type . ' cancelled',
+                default        => trim($row->employee_name) . ' applied for ' . $row->leave_type,
+            };
+
+            return [
+                'id'          => (int) $row->id,
+                'type'        => $type,
+                'title'       => $title,
+                'description' => $row->comment ?: ($row->approved_by ? 'Actioned by ' . $row->approved_by : 'Awaiting review'),
+                'timestamp'   => $row->activity_at,
+                'from_date'   => $row->from_date,
+                'to_date'     => $row->to_date,
+            ];
+        })->all();
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveDistributionApiController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveDistributionApiController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Leave distribution for the Leave Management dashboard.
+ *
+ * The legacy endpoint is Api\HRITDashboard\LeaveDistribution::leaveDistribution
+ * (GET /api/leave-distribution), which is left exactly as it is. This variant
+ * joins hrms_leave_types on its primary key (the legacy join compared the
+ * 'LTY0xx' code column against the integer FK, so leave_type_name was always
+ * null) and ignores soft deleted leave rows.
+ */
+class LeaveDistributionApiController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    /**
+     * GET /api/leave/distribution
+     */
+    public function index(Request $request)
+    {
+        $context = $this->leaveContext($request);
+
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $subInstituteId = $context['sub_institute_id'];
+        $departmentId = $this->activeFilter($request->input('department_id'));
+
+        $query = DB::table('tbluser as u')
+            ->leftJoin(DB::raw("(SELECT department_id, MIN(department) AS department
+                                FROM s_user_jobrole
+                                GROUP BY department_id) AS j"),
+                fn ($join) => $join->on('j.department_id', '=', 'u.department_id'))
+            ->join(DB::raw("(SELECT * FROM hrms_emp_leaves
+                            WHERE deleted_at IS NULL
+                              AND id IN (
+                                SELECT MAX(id)
+                                FROM hrms_emp_leaves
+                                WHERE deleted_at IS NULL
+                                GROUP BY user_id
+                            )) AS l"),
+                fn ($join) => $join->on('l.user_id', '=', 'u.id'))
+            // lt.leave_type_id is the 'LTY0xx' code while l.leave_type_id is the
+            // integer FK, so joining on the code can never match.
+            ->leftJoin('hrms_leave_types as lt', 'lt.id', '=', 'l.leave_type_id')
+            ->where('u.sub_institute_id', $subInstituteId);
+
+        if ($departmentId) {
+            $query->where('u.department_id', $departmentId);
+        }
+
+        $results = $query->select(
+                'lt.leave_type AS leave_type_name',
+                DB::raw("CASE
+                            WHEN l.day_type = 1 THEN 'Full Day Leave'
+                            WHEN l.day_type = 0.5 THEN 'Half Day Leave'
+                            ELSE 'Unknown'
+                        END AS leave_day_type"),
+                DB::raw('COUNT(*) AS leave_count')
+            )
+            ->groupBy('lt.leave_type', 'leave_day_type')
+            ->get();
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Leave distribution fetched successfully',
+            'data' => $results,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveOptionsController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveOptionsController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use App\Services\Leave\LeaveAnalyticsService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LeaveOptionsController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    public function __construct(private LeaveAnalyticsService $analytics)
+    {
+    }
+
+    /**
+     * GET /api/leave/options
+     *
+     * Every dropdown the Leave screens need, in a single round trip:
+     * departments, employees, leave types and the status vocabulary.
+     */
+    public function index(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $departmentId = $this->activeFilter($request->input('department_id'));
+
+        $departments = DB::table('hrms_departments')
+            ->select('id', 'department')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('status', 1)
+            ->whereNull('deleted_at')
+            ->orderBy('department')
+            ->get()
+            ->map(fn ($row) => ['value' => (string) $row->id, 'label' => $row->department]);
+
+        $employees = DB::table('tbluser as u')
+            ->leftJoin('hrms_departments as hd', 'hd.id', '=', 'u.department_id')
+            ->selectRaw("
+                u.id,
+                u.employee_no,
+                u.department_id,
+                COALESCE(hd.department, '') AS department,
+                CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) AS employee_name
+            ")
+            ->where('u.sub_institute_id', $context['sub_institute_id'])
+            ->where('u.status', 1)
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->orderBy('u.first_name')
+            ->get()
+            ->map(fn ($row) => [
+                'value'         => (string) $row->id,
+                'label'         => trim(preg_replace('/\s+/', ' ', (string) $row->employee_name)),
+                'employee_no'   => $row->employee_no,
+                'department_id' => $row->department_id ? (string) $row->department_id : null,
+                'department'    => $row->department,
+            ]);
+
+        $leaveTypes = $this->analytics->leaveTypes($context['sub_institute_id'])
+            ->map(fn ($row) => [
+                'value' => (string) $row->id,
+                'label' => $row->leave_type,
+                'code'  => $row->leave_type_id,
+            ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave options fetched successfully',
+            'year'    => $context['year'],
+            'data'    => [
+                'departments' => $departments,
+                'employees'   => $employees,
+                'leave_types' => $leaveTypes,
+                'statuses'    => [
+                    ['value' => 'pending',      'label' => 'Pending'],
+                    ['value' => 'approved',     'label' => 'Approved'],
+                    ['value' => 'rejected',     'label' => 'Rejected'],
+                    ['value' => 'sent_back',    'label' => 'Sent Back'],
+                    ['value' => 'cancelled',    'label' => 'Cancelled'],
+                    ['value' => 'approved_lwp', 'label' => 'Approved LWP'],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/leave/balances
+     * Balance snapshot for one employee (defaults to the caller).
+     */
+    public function balances(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $employeeId = (int) ($this->activeFilter($request->input('employee_id')) ?: $context['user_id']);
+
+        if (!$employeeId) {
+            return response()->json(['status' => 0, 'message' => 'employee_id is required'], 400);
+        }
+
+        $balances = $this->analytics->balancesForEmployee(
+            $context['sub_institute_id'],
+            $context['year'],
+            $employeeId
+        );
+
+        return response()->json([
+            'status'      => 1,
+            'message'     => 'Leave balances fetched successfully',
+            'year'        => $context['year'],
+            'employee_id' => $employeeId,
+            'data'        => $balances,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveReportApiController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveReportApiController.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use App\Services\Leave\LeaveAnalyticsService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LeaveReportApiController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    /**
+     * days = (DATEDIFF(to, from) + 1) * day_type - the SQL equivalent of
+     * App\Helpers\countDays() with no skip-day rule.
+     */
+    private const DAYS_EXPR = "((DATEDIFF(COALESCE(hel.to_date, hel.from_date), hel.from_date) + 1) * COALESCE(CAST(hel.day_type AS DECIMAL(4,2)), 1))";
+
+    public function __construct(private LeaveAnalyticsService $analytics)
+    {
+    }
+
+    /**
+     * GET /api/leave/reports/summary
+     * Feeds the Leave Summary report preview: one row per leave type.
+     */
+    public function summary(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = $this->filtered($context, $request)
+            ->selectRaw("
+                COALESCE(hlt.leave_type, 'Unassigned') AS leave_type,
+                COALESCE(hlt.id, 0) AS leave_type_id,
+                COALESCE(hlt.leave_type_id, '') AS leave_type_code,
+                COUNT(*) AS total,
+                SUM(CASE WHEN hel.status IN ('approved','approved_lwp') THEN 1 ELSE 0 END) AS approved,
+                SUM(CASE WHEN hel.status = 'pending' THEN 1 ELSE 0 END) AS pending,
+                SUM(CASE WHEN hel.status = 'rejected' THEN 1 ELSE 0 END) AS rejected,
+                SUM(CASE WHEN hel.status = 'cancelled' THEN 1 ELSE 0 END) AS cancelled,
+                SUM(CASE WHEN hel.status = 'sent_back' THEN 1 ELSE 0 END) AS sent_back,
+                ROUND(SUM(CASE WHEN hel.status IN ('approved','pending','approved_lwp') THEN " . self::DAYS_EXPR . " ELSE 0 END), 2) AS days
+            ")
+            ->groupBy('hlt.id', 'hlt.leave_type', 'hlt.leave_type_id')
+            ->orderByDesc('total')
+            ->get()
+            ->map(fn ($row) => [
+                'leave_type_id'   => (int) $row->leave_type_id,
+                'leave_type'      => $row->leave_type,
+                'leave_type_code' => $row->leave_type_code,
+                'total'           => (int) $row->total,
+                'approved'        => (int) $row->approved,
+                'pending'         => (int) $row->pending,
+                'rejected'        => (int) $row->rejected,
+                'cancelled'       => (int) $row->cancelled,
+                'sent_back'       => (int) $row->sent_back,
+                'days'            => (float) $row->days,
+            ]);
+
+        $departmentBreakdown = $this->filtered($context, $request)
+            ->selectRaw("COALESCE(hd.department, 'Unassigned') AS department, COUNT(*) AS total")
+            ->groupBy('hd.id', 'hd.department')
+            ->orderByDesc('total')
+            ->get();
+
+        $grandTotal = (int) $departmentBreakdown->sum('total');
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave summary report fetched successfully',
+            'year'    => $context['year'],
+            'data'    => [
+                'rows'    => $rows,
+                'totals'  => [
+                    'total'     => (int) $rows->sum('total'),
+                    'approved'  => (int) $rows->sum('approved'),
+                    'pending'   => (int) $rows->sum('pending'),
+                    'rejected'  => (int) $rows->sum('rejected'),
+                    'cancelled' => (int) $rows->sum('cancelled'),
+                    'sent_back' => (int) $rows->sum('sent_back'),
+                    'days'      => round((float) $rows->sum('days'), 2),
+                ],
+                'department_breakdown' => $departmentBreakdown->map(fn ($row) => [
+                    'department' => $row->department,
+                    'total'      => (int) $row->total,
+                    'percentage' => $grandTotal > 0 ? round(((int) $row->total / $grandTotal) * 100, 2) : 0,
+                ]),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/leave/reports/register
+     * Row-level register / employee leave history export.
+     */
+    public function register(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $limit = min(max((int) $request->input('limit', 500), 1), 5000);
+
+        $rows = $this->filtered($context, $request)
+            ->selectRaw("
+                hel.id,
+                hel.user_id,
+                hel.from_date,
+                hel.to_date,
+                hel.day_type,
+                hel.status,
+                hel.comment,
+                hel.approved_by,
+                hel.created_at,
+                u.employee_no,
+                CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) AS employee_name,
+                COALESCE(hd.department, 'Unassigned') AS department,
+                COALESCE(hlt.leave_type, 'Unassigned') AS leave_type,
+                ROUND(" . self::DAYS_EXPR . ", 2) AS days
+            ")
+            ->orderBy('hel.from_date', 'desc')
+            ->limit($limit)
+            ->get()
+            ->map(fn ($row) => [
+                'id'             => (int) $row->id,
+                'employee_id'    => (int) $row->user_id,
+                'employee_no'    => $row->employee_no,
+                'employee_name'  => trim(preg_replace('/\s+/', ' ', (string) $row->employee_name)),
+                'department'     => $row->department,
+                'leave_type'     => $row->leave_type,
+                'from_date'      => $row->from_date,
+                'to_date'        => $row->to_date,
+                'days'           => (float) $row->days,
+                'duration'       => $this->analytics->durationLabel((float) $row->days),
+                'status'         => $row->status,
+                'reason'         => $row->comment,
+                'approver'       => $row->approved_by,
+                'submitted_date' => $row->created_at,
+            ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave register fetched successfully',
+            'year'    => $context['year'],
+            'count'   => $rows->count(),
+            'data'    => $rows,
+        ]);
+    }
+
+    /**
+     * GET /api/leave/reports/balance
+     * Entitlement / used / remaining per employee per leave type.
+     */
+    public function balance(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $departmentId = $this->activeFilter($request->input('department_id'));
+        $employeeId   = $this->activeFilter($request->input('employee_id'));
+
+        $entitlement = $this->analytics->entitlementByType(
+            $context['sub_institute_id'],
+            $context['year'],
+            $departmentId ? (int) $departmentId : null,
+            $employeeId ? (int) $employeeId : null
+        );
+
+        $consumed = $this->analytics->consumedByType(
+            $context['sub_institute_id'],
+            $context['year'],
+            $departmentId ? (int) $departmentId : null,
+            $employeeId ? (int) $employeeId : null
+        );
+
+        $userIds = collect($entitlement)->merge($consumed)
+            ->flatMap(fn ($byUser) => array_keys($byUser))
+            ->unique()
+            ->values();
+
+        if ($userIds->isEmpty()) {
+            return response()->json([
+                'status'  => 1,
+                'message' => 'Leave balance report fetched successfully',
+                'year'    => $context['year'],
+                'data'    => ['leave_types' => [], 'rows' => []],
+            ]);
+        }
+
+        $employees = DB::table('tbluser as u')
+            ->leftJoin('hrms_departments as hd', 'hd.id', '=', 'u.department_id')
+            ->selectRaw("
+                u.id, u.employee_no,
+                CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) AS employee_name,
+                COALESCE(hd.department, 'Unassigned') AS department
+            ")
+            ->whereIn('u.id', $userIds)
+            ->orderBy('u.first_name')
+            ->get();
+
+        $leaveTypeNames = collect(array_keys($entitlement))
+            ->merge(array_keys($consumed))
+            ->unique()
+            ->sort()
+            ->values();
+
+        $rows = $employees->map(function ($employee) use ($leaveTypeNames, $entitlement, $consumed) {
+            $balances = [];
+
+            foreach ($leaveTypeNames as $name) {
+                $total = (float) ($entitlement[$name][$employee->id] ?? 0);
+                $used  = (float) ($consumed[$name][$employee->id] ?? 0);
+
+                $balances[$name] = [
+                    'total'     => round($total, 2),
+                    'used'      => round($used, 2),
+                    'remaining' => $total > 0 ? round($total - $used, 2) : 0.0,
+                ];
+            }
+
+            return [
+                'employee_id'   => (int) $employee->id,
+                'employee_no'   => $employee->employee_no,
+                'employee_name' => trim(preg_replace('/\s+/', ' ', (string) $employee->employee_name)),
+                'department'    => $employee->department,
+                'balances'      => $balances,
+            ];
+        });
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave balance report fetched successfully',
+            'year'    => $context['year'],
+            'data'    => [
+                'leave_types' => $leaveTypeNames,
+                'rows'        => $rows,
+            ],
+        ]);
+    }
+
+    /** Shared filter set for every report. */
+    private function filtered(array $context, Request $request)
+    {
+        $query = $this->analytics->requestsQuery($context['sub_institute_id'], $context['year']);
+
+        $departments = $this->filterList($request->input('department_id'));
+        $employees   = $this->filterList($request->input('employee_id'));
+        $leaveTypes  = $this->filterList($request->input('leave_type_id'));
+        $statuses    = $this->filterList($request->input('status'));
+        $fromDate    = $this->activeFilter($request->input('from_date'));
+        $toDate      = $this->activeFilter($request->input('to_date'));
+        $activeOnly  = $request->input('employee_status', 'active');
+
+        if (!empty($departments)) {
+            $query->whereIn('u.department_id', $departments);
+        }
+
+        if (!empty($employees)) {
+            $query->whereIn('hel.user_id', $employees);
+        }
+
+        if (!empty($leaveTypes)) {
+            $query->whereIn('hel.leave_type_id', $leaveTypes);
+        }
+
+        if (!empty($statuses)) {
+            $query->whereIn('hel.status', $statuses);
+        }
+
+        if ($fromDate) {
+            $query->where('hel.to_date', '>=', $fromDate);
+        }
+
+        if ($toDate) {
+            $query->where('hel.from_date', '<=', $toDate);
+        }
+
+        if ($activeOnly === 'active') {
+            $query->where('u.status', 1);
+        } elseif ($activeOnly === 'inactive') {
+            $query->where('u.status', '!=', 1);
+        }
+
+        return $query;
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveRequestApiController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveRequestApiController.php
@@ -1,0 +1,577 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use App\Services\Leave\LeaveAnalyticsService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class LeaveRequestApiController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    /** Statuses an approver may move a request into. */
+    private const DECISION_STATUSES = ['approved', 'rejected', 'sent_back', 'cancelled', 'approved_lwp'];
+
+    private const SORTABLE = [
+        'employee_name' => 'employee_name',
+        'department'    => 'hd.department',
+        'leaveType'     => 'hlt.leave_type',
+        'fromDate'      => 'hel.from_date',
+        'toDate'        => 'hel.to_date',
+        'status'        => 'hel.status',
+        'submittedDate' => 'hel.created_at',
+        'id'            => 'hel.id',
+    ];
+
+    public function __construct(private LeaveAnalyticsService $analytics)
+    {
+    }
+
+    /**
+     * GET /api/leave/requests
+     *
+     * Server side search + filter + sort + pagination for the Leave Requests table.
+     */
+    public function index(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $perPage = min(max((int) $request->input('per_page', 10), 1), 200);
+        $page    = max((int) $request->input('page', 1), 1);
+
+        $query = $this->applyFilters(
+            $this->analytics->requestsQuery($context['sub_institute_id'], $context['year']),
+            $request
+        );
+
+        $total = (clone $query)->count('hel.id');
+
+        $sortBy  = self::SORTABLE[$request->input('sort_by')] ?? 'hel.from_date';
+        $sortDir = strtolower($request->input('sort_dir', 'desc')) === 'asc' ? 'asc' : 'desc';
+
+        $rows = $query
+            ->selectRaw("
+                hel.*,
+                CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) AS employee_name,
+                u.employee_no,
+                u.email,
+                u.mobile,
+                u.image,
+                u.department_id AS user_department_id,
+                COALESCE(hd.department, '') AS department,
+                COALESCE(hjt.title, '') AS designation,
+                COALESCE(hlt.leave_type, '') AS leave_type,
+                hlt.leave_type_id AS leave_type_code
+            ")
+            ->orderBy($sortBy, $sortDir)
+            ->orderByDesc('hel.id')
+            ->forPage($page, $perPage)
+            ->get()
+            ->map(fn ($row) => $this->transform($row));
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Leave requests fetched successfully',
+            'year'       => $context['year'],
+            'data'       => $rows,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/leave/requests/{id}
+     * Single request with balance snapshot, comments and timeline.
+     */
+    public function show(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $row = $this->analytics
+            ->requestsQuery($context['sub_institute_id'], $context['year'])
+            ->selectRaw("
+                hel.*,
+                CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) AS employee_name,
+                u.employee_no, u.email, u.mobile, u.image,
+                u.department_id AS user_department_id,
+                COALESCE(hd.department, '') AS department,
+                COALESCE(hjt.title, '') AS designation,
+                COALESCE(hlt.leave_type, '') AS leave_type,
+                hlt.leave_type_id AS leave_type_code
+            ")
+            ->where('hel.id', $id)
+            ->first();
+
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Leave request not found'], 404);
+        }
+
+        $balances = $this->analytics->balancesForEmployee(
+            $context['sub_institute_id'],
+            $context['year'],
+            (int) $row->user_id
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave request fetched successfully',
+            'data'    => array_merge($this->transform($row), [
+                'balances' => $balances['leave_types'],
+                'comments' => $this->comments($row),
+                'timeline' => $this->timeline($row),
+            ]),
+        ]);
+    }
+
+    /**
+     * POST /api/leave/requests
+     * Apply for leave. Mirrors ApplyLeaveController::store but with the validation
+     * rules that were commented out there, and with status actually set.
+     */
+    public function store(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'leave_type_id' => 'required|integer|exists:hrms_leave_types,id',
+            'day_type'      => 'required|in:full,half',
+            'from_date'     => 'required|date',
+            'to_date'       => 'required_if:day_type,full|nullable|date|after_or_equal:from_date',
+            'slot'          => 'required_if:day_type,half|nullable|in:first_half,second_half',
+            'comment'       => 'required|string|max:255',
+            'employee_id'   => 'nullable|integer|exists:tbluser,id',
+            'department_id' => 'nullable|integer',
+        ], [
+            'comment.required' => 'A reason is required.',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $userId = (int) ($request->input('employee_id') ?: $context['user_id']);
+
+        if (!$userId) {
+            return response()->json(['status' => 0, 'message' => 'Unable to resolve the employee for this request'], 422);
+        }
+
+        $isHalfDay = $request->input('day_type') === 'half';
+        $fromDate  = $request->input('from_date');
+        $toDate    = $isHalfDay ? $fromDate : ($request->input('to_date') ?: $fromDate);
+
+        $departmentId = $request->input('department_id')
+            ?: DB::table('tbluser')->where('id', $userId)->value('department_id');
+
+        $payload = [
+            'sub_institute_id' => $context['sub_institute_id'],
+            'department_id'    => $departmentId,
+            'user_id'          => $userId,
+            'leave_type_id'    => (int) $request->input('leave_type_id'),
+            'day_type'         => $isHalfDay ? '0.5' : '1',
+            'slot'             => $isHalfDay ? $request->input('slot') : null,
+            'from_date'        => $fromDate,
+            'to_date'          => $toDate,
+            'comment'          => $request->input('comment'),
+            'status'           => 'pending',
+        ];
+
+        // Preserve the legacy upsert: re-applying for the same start date edits the
+        // employee's existing pending row rather than creating a duplicate.
+        $existing = DB::table('hrms_emp_leaves')
+            ->where('user_id', $userId)
+            ->where('from_date', $fromDate)
+            ->where('status', 'pending')
+            ->whereNull('deleted_at')
+            ->first();
+
+        if ($existing) {
+            $payload['updated_at'] = now();
+            $payload['updated_by'] = $context['user_id'];
+            DB::table('hrms_emp_leaves')->where('id', $existing->id)->update($payload);
+            $leaveId = (int) $existing->id;
+            $message = 'Leave request updated successfully';
+        } else {
+            $payload['created_at'] = now();
+            $payload['created_by'] = $context['user_id'];
+            $leaveId = (int) DB::table('hrms_emp_leaves')->insertGetId($payload);
+            $message = 'Leave applied successfully';
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => $message,
+            'data'    => ['id' => $leaveId],
+        ], $existing ? 200 : 201);
+    }
+
+    /**
+     * POST /api/leave/requests/{id}/decision
+     */
+    public function decision(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'status'      => 'required|in:' . implode(',', self::DECISION_STATUSES),
+            'hod_comment' => 'nullable|string|max:50',
+            'hr_remarks'  => 'nullable|string|max:100',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $exists = DB::table('hrms_emp_leaves')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->exists();
+
+        if (!$exists) {
+            return response()->json(['status' => 0, 'message' => 'Leave request not found'], 404);
+        }
+
+        $updated = $this->applyDecision(
+            [$id],
+            $request->input('status'),
+            [$id => $request->input('hod_comment')],
+            [$id => $request->input('hr_remarks')],
+            $context
+        );
+
+        return response()->json([
+            'status'        => $updated ? 1 : 0,
+            'message'       => $updated ? 'Leave request updated successfully' : 'No leave request updated',
+            'updated_count' => $updated,
+        ], $updated ? 200 : 400);
+    }
+
+    /**
+     * POST /api/leave/requests/bulk-decision
+     * Fixes the legacy leaveAuthorisationStore, which returned from inside its own
+     * loop and therefore only ever updated the first selected record.
+     */
+    public function bulkDecision(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'ids'           => 'required|array|min:1',
+            'ids.*'         => 'integer',
+            'status'        => 'required|in:' . implode(',', self::DECISION_STATUSES),
+            'hod_comment'   => 'nullable|array',
+            'hr_remarks'    => 'nullable|array',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $ids = DB::table('hrms_emp_leaves')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereIn('id', $request->input('ids'))
+            ->whereNull('deleted_at')
+            ->pluck('id')
+            ->all();
+
+        if (empty($ids)) {
+            return response()->json(['status' => 0, 'message' => 'No matching leave requests found'], 404);
+        }
+
+        $updated = $this->applyDecision(
+            $ids,
+            $request->input('status'),
+            (array) $request->input('hod_comment', []),
+            (array) $request->input('hr_remarks', []),
+            $context
+        );
+
+        return response()->json([
+            'status'        => $updated ? 1 : 0,
+            'message'       => $updated
+                ? $updated . ' leave request(s) updated successfully'
+                : 'No leave request updated',
+            'updated_count' => $updated,
+        ], $updated ? 200 : 400);
+    }
+
+    /**
+     * DELETE /api/leave/requests/{id}
+     * Withdrawal by the applicant - soft delete, never a hard delete, so the
+     * audit trail survives.
+     */
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $leave = DB::table('hrms_emp_leaves')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$leave) {
+            return response()->json(['status' => 0, 'message' => 'Leave request not found'], 404);
+        }
+
+        if ($leave->status !== 'pending') {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'Only a pending leave request can be withdrawn',
+            ], 422);
+        }
+
+        DB::table('hrms_emp_leaves')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        return response()->json(['status' => 1, 'message' => 'Leave request withdrawn successfully']);
+    }
+
+    /** Shared write path for single and bulk decisions. */
+    private function applyDecision(array $ids, string $status, array $hodComments, array $hrRemarks, array $context): int
+    {
+        // Resolve by id alone: an approver acting on an institute's requests is not
+        // necessarily a member of it (the legacy leaveAuthorisationStore filtered on
+        // sub_institute_id here and silently wrote a null approved_by whenever the two
+        // differed). Fall back to a label rather than storing nothing.
+        $approverName = DB::table('tbluser')
+            ->selectRaw("TRIM(CONCAT_WS(' ', first_name, last_name)) AS employee_name")
+            ->where('id', $context['user_id'])
+            ->value('employee_name');
+
+        $approverName = $approverName ?: 'User #' . $context['user_id'];
+
+        $updated = 0;
+
+        DB::transaction(function () use ($ids, $status, $hodComments, $hrRemarks, $approverName, $context, &$updated) {
+            foreach ($ids as $id) {
+                $payload = [
+                    'status'      => $status,
+                    'approved_by' => $approverName,
+                    'updated_at'  => now(),
+                    'updated_by'  => $context['user_id'],
+                ];
+
+                if (array_key_exists($id, $hodComments) && $hodComments[$id] !== null && $hodComments[$id] !== '') {
+                    $payload['hod_comment']      = $hodComments[$id];
+                    $payload['hod_comment_date'] = now();
+                }
+
+                if (array_key_exists($id, $hrRemarks) && $hrRemarks[$id] !== null && $hrRemarks[$id] !== '') {
+                    $payload['hr_remarks']     = $hrRemarks[$id];
+                    $payload['hr_remark_date'] = now();
+                }
+
+                $updated += DB::table('hrms_emp_leaves')
+                    ->where('id', $id)
+                    ->where('sub_institute_id', $context['sub_institute_id'])
+                    ->update($payload);
+            }
+        });
+
+        return $updated;
+    }
+
+    private function applyFilters($query, Request $request)
+    {
+        $search       = trim((string) $request->input('search', ''));
+        $statuses     = $this->filterList($request->input('status'));
+        $departments  = $this->filterList($request->input('department_id'));
+        $leaveTypes   = $this->filterList($request->input('leave_type_id'));
+        $employees    = $this->filterList($request->input('employee_id'));
+        $fromDate     = $this->activeFilter($request->input('from_date'));
+        $toDate       = $this->activeFilter($request->input('to_date'));
+
+        if ($search !== '') {
+            $query->where(function ($q) use ($search) {
+                $like = '%' . $search . '%';
+                $q->whereRaw("CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) LIKE ?", [$like])
+                  ->orWhere('u.employee_no', 'like', $like)
+                  ->orWhere('u.email', 'like', $like)
+                  ->orWhere('hel.id', 'like', $like)
+                  ->orWhere('hel.comment', 'like', $like);
+            });
+        }
+
+        if (!empty($statuses)) {
+            $query->whereIn('hel.status', $statuses);
+        }
+
+        if (!empty($departments)) {
+            $query->whereIn('u.department_id', $departments);
+        }
+
+        if (!empty($leaveTypes)) {
+            $query->whereIn('hel.leave_type_id', $leaveTypes);
+        }
+
+        if (!empty($employees)) {
+            $query->whereIn('hel.user_id', $employees);
+        }
+
+        // Overlap, not containment: a leave spanning the window edge still belongs in it.
+        if ($fromDate) {
+            $query->where('hel.to_date', '>=', $fromDate);
+        }
+
+        if ($toDate) {
+            $query->where('hel.from_date', '<=', $toDate);
+        }
+
+        return $query;
+    }
+
+    /** Row shape consumed by the Next.js LeaveRequest type. */
+    private function transform($row): array
+    {
+        $days = $this->analytics->requestDays($row->from_date, $row->to_date, $row->day_type);
+
+        return [
+            'id'             => (int) $row->id,
+            'employee_id'    => (int) $row->user_id,
+            'employee_no'    => $row->employee_no,
+            'employee_name'  => trim(preg_replace('/\s+/', ' ', (string) $row->employee_name)),
+            'designation'    => $row->designation ?: null,
+            'email'          => $row->email,
+            'mobile'         => $row->mobile,
+            'avatar'         => $row->image ?: null,
+            'department_id'  => (int) ($row->user_department_id ?? $row->department_id ?? 0),
+            'department'     => $row->department ?: 'Unassigned',
+            'leave_type_id'  => (int) $row->leave_type_id,
+            'leave_type'     => $row->leave_type ?: 'Unassigned',
+            'leave_type_code'=> $row->leave_type_code ?? null,
+            'day_type'       => $row->day_type,
+            'slot'           => $row->slot,
+            'session'        => ((string) $row->day_type === '0.5') ? 'Half Day' : 'Full Day',
+            'days'           => $days,
+            'duration'       => $this->analytics->durationLabel($days),
+            'from_date'      => $row->from_date,
+            'to_date'        => $row->to_date,
+            'status'         => $row->status,
+            'reason'         => $row->comment,
+            'hod_comment'    => $row->hod_comment,
+            'hod_comment_date' => $row->hod_comment_date,
+            'hr_remarks'     => $row->hr_remarks,
+            'hr_remark_date' => $row->hr_remark_date,
+            'approver'       => $row->approved_by,
+            'submitted_date' => $row->created_at,
+            'updated_date'   => $row->updated_at,
+        ];
+    }
+
+    private function comments($row): array
+    {
+        $comments = [];
+
+        if ($row->comment) {
+            $comments[] = [
+                'author'    => trim((string) $row->employee_name),
+                'role'      => 'Employee',
+                'body'      => $row->comment,
+                'timestamp' => $row->created_at,
+            ];
+        }
+
+        if ($row->hod_comment) {
+            $comments[] = [
+                'author'    => $row->approved_by ?: 'Department Head',
+                'role'      => 'Department Head',
+                'body'      => $row->hod_comment,
+                'timestamp' => $row->hod_comment_date,
+            ];
+        }
+
+        if ($row->hr_remarks) {
+            $comments[] = [
+                'author'    => $row->approved_by ?: 'HR',
+                'role'      => 'HR',
+                'body'      => $row->hr_remarks,
+                'timestamp' => $row->hr_remark_date,
+            ];
+        }
+
+        return $comments;
+    }
+
+    private function timeline($row): array
+    {
+        $timeline = [[
+            'stage'     => 'Request submitted',
+            'status'    => 'completed',
+            'actor'     => trim((string) $row->employee_name),
+            'timestamp' => $row->created_at,
+        ]];
+
+        if ($row->hod_comment_date) {
+            $timeline[] = [
+                'stage'     => 'Department head reviewed',
+                'status'    => 'completed',
+                'actor'     => $row->approved_by,
+                'timestamp' => $row->hod_comment_date,
+            ];
+        }
+
+        if ($row->hr_remark_date) {
+            $timeline[] = [
+                'stage'     => 'HR reviewed',
+                'status'    => 'completed',
+                'actor'     => $row->approved_by,
+                'timestamp' => $row->hr_remark_date,
+            ];
+        }
+
+        if ($row->status !== 'pending') {
+            $decidedAt = $row->hr_remark_date ?: ($row->hod_comment_date ?: $row->updated_at);
+
+            $timeline[] = [
+                'stage'     => 'Request ' . str_replace('_', ' ', $row->status),
+                'status'    => $row->status,
+                'actor'     => $row->approved_by,
+                'timestamp' => $decidedAt ? Carbon::parse($decidedAt)->toDateTimeString() : null,
+            ];
+        }
+
+        return $timeline;
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveTypeApiController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveTypeApiController.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Leave type configuration.
+ *
+ * The annual quota does not live on hrms_leave_types - it lives in
+ * hrms_leave_allocation, keyed by (department, employee, leave_type, year).
+ * This controller surfaces the department level allocation for the current
+ * leave year as "annual_quota" and writes it back to that table, so the two
+ * screens (Configuration and Leave Allocation) stay consistent.
+ */
+class LeaveTypeApiController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    /**
+     * GET /api/leave/leave-types
+     */
+    public function index(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $leaveTypes = DB::table('hrms_leave_types')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->orderBy('sort_order')
+            ->get();
+
+        $allocations = DB::table('hrms_leave_allocation as hla')
+            ->leftJoin('hrms_departments as hd', 'hd.id', '=', 'hla.department_id')
+            ->selectRaw('hla.leave_type_id, hla.department_id, hla.value, COALESCE(hd.department, "") AS department')
+            ->where('hla.sub_institute_id', $context['sub_institute_id'])
+            ->where('hla.year', $context['year'])
+            ->whereNull('hla.deleted_at')
+            ->where(function ($q) {
+                $q->whereNull('hla.employee_id')->orWhere('hla.employee_id', 0);
+            })
+            ->get()
+            ->groupBy('leave_type_id');
+
+        $data = $leaveTypes->map(function ($type) use ($allocations) {
+            $rows = $allocations->get($type->id, collect());
+            $values = $rows->pluck('value')->map(fn ($value) => (float) $value)->unique()->values();
+
+            return [
+                'id'                  => (int) $type->id,
+                'leave_type_id'       => $type->leave_type_id,
+                'leave_type'          => $type->leave_type,
+                'sort_order'          => (int) ($type->sort_order ?? 0),
+                'carry_forward'       => (bool) ($type->carry_forward ?? false),
+                'status'              => (int) ($type->status ?? 0),
+                // Null when departments disagree - the UI then shows the per-department breakdown.
+                'annual_quota'        => $values->count() === 1 ? $values->first() : null,
+                'annual_quota_varies' => $values->count() > 1,
+                'allocations'         => $rows->map(fn ($row) => [
+                    'department_id' => (int) $row->department_id,
+                    'department'    => $row->department,
+                    'value'         => (float) $row->value,
+                ])->values(),
+            ];
+        });
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Leave types fetched successfully',
+            'year'    => $context['year'],
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * POST /api/leave/leave-types      (create)
+     * PUT  /api/leave/leave-types/{id} (update)
+     */
+    public function store(Request $request, $id = null)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $id = $id ?: $request->input('id');
+
+        $validator = Validator::make(array_merge($request->all(), ['id' => $id]), [
+            'leave_type'    => 'required|string|max:191',
+            'sort_order'    => 'nullable|integer|min:0',
+            'status'        => 'nullable|boolean',
+            'carry_forward' => 'nullable|boolean',
+            'annual_quota'  => 'nullable|numeric|min:0|max:365',
+            'department_id' => 'nullable|integer',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $name = trim($request->input('leave_type'));
+
+        $duplicate = DB::table('hrms_leave_types')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('leave_type', $name)
+            ->whereNull('deleted_at')
+            ->when($id, fn ($q) => $q->where('id', '!=', $id))
+            ->exists();
+
+        if ($duplicate) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'A leave type with this name already exists',
+                'errors'  => ['leave_type' => ['A leave type with this name already exists']],
+            ], 422);
+        }
+
+        $payload = [
+            'leave_type'       => $name,
+            'sort_order'       => (int) $request->input('sort_order', 0),
+            'status'           => $request->boolean('status', true) ? 1 : 0,
+            'carry_forward'    => $request->boolean('carry_forward') ? 1 : 0,
+            'sub_institute_id' => $context['sub_institute_id'],
+            'deleted_at'       => null,
+        ];
+
+        if ($id && DB::table('hrms_leave_types')->where('id', $id)->where('sub_institute_id', $context['sub_institute_id'])->exists()) {
+            $payload['updated_at'] = now();
+            $payload['updated_by'] = $context['user_id'];
+            DB::table('hrms_leave_types')->where('id', $id)->update($payload);
+            $leaveTypeId = (int) $id;
+            $message = 'Leave type updated successfully';
+            $code = 200;
+        } else {
+            $payload['leave_type_id'] = $request->input('leave_type_id') ?: $this->nextLeaveTypeCode($context['sub_institute_id']);
+            $payload['created_at']    = now();
+            $payload['created_by']    = $context['user_id'];
+            $leaveTypeId = (int) DB::table('hrms_leave_types')->insertGetId($payload);
+            $message = 'Leave type added successfully';
+            $code = 201;
+        }
+
+        if ($request->filled('annual_quota')) {
+            $this->syncAllocation(
+                $context,
+                $leaveTypeId,
+                (float) $request->input('annual_quota'),
+                $this->activeFilter($request->input('department_id'))
+            );
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => $message,
+            'data'    => ['id' => $leaveTypeId],
+        ], $code);
+    }
+
+    /**
+     * PATCH /api/leave/leave-types/{id}/status
+     * Enable / disable without touching any other field.
+     */
+    public function toggleStatus(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $leaveType = DB::table('hrms_leave_types')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$leaveType) {
+            return response()->json(['status' => 0, 'message' => 'Leave type not found'], 404);
+        }
+
+        $next = $request->has('status') ? ($request->boolean('status') ? 1 : 0) : ((int) $leaveType->status === 1 ? 0 : 1);
+
+        DB::table('hrms_leave_types')->where('id', $id)->update([
+            'status'     => $next,
+            'updated_at' => now(),
+            'updated_by' => $context['user_id'],
+        ]);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => $next ? 'Leave type enabled' : 'Leave type disabled',
+            'data'    => ['id' => (int) $id, 'status' => $next],
+        ]);
+    }
+
+    /**
+     * DELETE /api/leave/leave-types/{id}
+     */
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $leaveType = DB::table('hrms_leave_types')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$leaveType) {
+            return response()->json(['status' => 0, 'message' => 'Leave type not found'], 404);
+        }
+
+        $inUse = DB::table('hrms_emp_leaves')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('leave_type_id', $id)
+            ->whereNull('deleted_at')
+            ->exists();
+
+        if ($inUse && !$request->boolean('force')) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'This leave type is used by existing leave requests. Disable it instead, or resend with force=1.',
+            ], 409);
+        }
+
+        DB::table('hrms_leave_types')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        return response()->json(['status' => 1, 'message' => 'Leave type deleted successfully']);
+    }
+
+    /** Next LTY sequence for the institute. */
+    private function nextLeaveTypeCode(int $subInstituteId): string
+    {
+        $last = DB::table('hrms_leave_types')
+            ->where('sub_institute_id', $subInstituteId)
+            ->whereNotNull('leave_type_id')
+            ->orderByDesc('id')
+            ->value('leave_type_id');
+
+        $next = $last && preg_match('/(\d+)$/', $last, $matches) ? ((int) $matches[1]) + 1 : 1;
+
+        return 'LTY' . str_pad((string) $next, 3, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Write the annual quota into hrms_leave_allocation for the leave year.
+     * With no department_id it applies to every active department.
+     */
+    private function syncAllocation(array $context, int $leaveTypeId, float $value, ?string $departmentId): void
+    {
+        $departmentIds = $departmentId
+            ? [(int) $departmentId]
+            : DB::table('hrms_departments')
+                ->where('sub_institute_id', $context['sub_institute_id'])
+                ->where('status', 1)
+                ->whereNull('deleted_at')
+                ->pluck('id')
+                ->all();
+
+        foreach ($departmentIds as $department) {
+            $existing = DB::table('hrms_leave_allocation')
+                ->where('sub_institute_id', $context['sub_institute_id'])
+                ->where('department_id', $department)
+                ->where('leave_type_id', $leaveTypeId)
+                ->where('year', $context['year'])
+                ->where(function ($q) {
+                    $q->whereNull('employee_id')->orWhere('employee_id', 0);
+                })
+                ->first();
+
+            if ($existing) {
+                DB::table('hrms_leave_allocation')->where('id', $existing->id)->update([
+                    'value'      => $value,
+                    'deleted_at' => null,
+                    'updated_at' => now(),
+                    'updated_by' => $context['user_id'],
+                ]);
+            } else {
+                DB::table('hrms_leave_allocation')->insert([
+                    'department_id'    => $department,
+                    'employee_id'      => null,
+                    'leave_type_id'    => $leaveTypeId,
+                    'year'             => $context['year'],
+                    'value'            => $value,
+                    'sub_institute_id' => $context['sub_institute_id'],
+                    'created_at'       => now(),
+                    'created_by'       => $context['user_id'],
+                ]);
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Api/Leave/LeaveWorkflowApiController.php
+++ b/app/Http/Controllers/Api/Leave/LeaveWorkflowApiController.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace App\Http\Controllers\Api\Leave;
+
+use App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext;
+use App\Http\Controllers\Controller;
+use App\Models\HRMS\HrmsLeaveRolePermission;
+use App\Models\HRMS\HrmsLeaveWorkflowSetting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Approval Workflow and Roles & Access configuration.
+ *
+ * Both were UI-only in the Next.js Configuration screen with no backing table
+ * anywhere in Laravel. Each institute gets a row seeded from the documented
+ * defaults on first read, so the screen is never empty.
+ */
+class LeaveWorkflowApiController extends Controller
+{
+    use ResolvesLeaveContext;
+
+    /**
+     * GET /api/leave/workflow
+     */
+    public function workflow(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $settings = $this->resolveWorkflow($context);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Approval workflow fetched successfully',
+            'data'    => $this->transformWorkflow($settings),
+        ]);
+    }
+
+    /**
+     * PUT /api/leave/workflow
+     */
+    public function saveWorkflow(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'reporting_manager_enabled' => 'required|boolean',
+            'department_head_enabled'   => 'required|boolean',
+            'hr_enabled'                => 'required|boolean',
+            'multi_level_enabled'       => 'required|boolean',
+            'multi_level_count'         => 'required_if:multi_level_enabled,1,true|nullable|integer|min:2|max:4',
+            'escalation_enabled'        => 'required|boolean',
+            'escalation_time'           => 'required_if:escalation_enabled,1,true|nullable|integer|min:1|max:8760',
+            'escalation_unit'           => 'required_if:escalation_enabled,1,true|nullable|in:hours,days',
+            'escalate_to'               => 'required_if:escalation_enabled,1,true|nullable|in:department-head,hr,admin',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        if (!$request->boolean('reporting_manager_enabled')
+            && !$request->boolean('department_head_enabled')
+            && !$request->boolean('hr_enabled')) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'At least one approval stage must be enabled',
+            ], 422);
+        }
+
+        $settings = $this->resolveWorkflow($context);
+
+        $settings->fill([
+            'reporting_manager_enabled' => $request->boolean('reporting_manager_enabled'),
+            'department_head_enabled'   => $request->boolean('department_head_enabled'),
+            'hr_enabled'                => $request->boolean('hr_enabled'),
+            'multi_level_enabled'       => $request->boolean('multi_level_enabled'),
+            'multi_level_count'         => (int) ($request->input('multi_level_count') ?: 2),
+            'escalation_enabled'        => $request->boolean('escalation_enabled'),
+            'escalation_time'           => (int) ($request->input('escalation_time') ?: 24),
+            'escalation_unit'           => $request->input('escalation_unit') ?: 'hours',
+            'escalate_to'               => $request->input('escalate_to') ?: 'hr',
+            'updated_by'                => $context['user_id'],
+        ])->save();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Approval workflow saved successfully',
+            'data'    => $this->transformWorkflow($settings->fresh()),
+        ]);
+    }
+
+    /**
+     * GET /api/leave/roles
+     */
+    public function roles(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Role permissions fetched successfully',
+            'data'    => $this->resolveRoles($context)->map(fn ($role) => $this->transformRole($role))->values(),
+        ]);
+    }
+
+    /**
+     * PUT /api/leave/roles
+     * Accepts the whole matrix in one call, matching how the tab saves.
+     */
+    public function saveRoles(Request $request)
+    {
+        $context = $this->leaveContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'roles'                      => 'required|array|min:1',
+            'roles.*.id'                 => 'nullable|integer',
+            'roles.*.role_name'          => 'required|string|max:100',
+            'roles.*.scope'              => 'required|in:Self,Team,Department,Organization',
+            'roles.*.approve_leave'      => 'required|boolean',
+            'roles.*.view_reports'       => 'required|boolean',
+            'roles.*.configure_settings' => 'required|boolean',
+            'roles.*.bulk_operations'    => 'required|boolean',
+            'roles.*.escalation_rights'  => 'required|boolean',
+            'roles.*.user_management'    => 'required|boolean',
+            'roles.*.status'             => 'nullable|boolean',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        // Ensure the institute always keeps at least one role that can configure settings,
+        // otherwise nobody can ever reach this screen again.
+        $hasConfigurer = collect($request->input('roles'))
+            ->contains(fn ($role) => filter_var($role['configure_settings'] ?? false, FILTER_VALIDATE_BOOLEAN));
+
+        if (!$hasConfigurer) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'At least one role must retain the Configure Settings permission',
+            ], 422);
+        }
+
+        $this->resolveRoles($context);
+
+        DB::transaction(function () use ($request, $context) {
+            foreach ($request->input('roles') as $index => $role) {
+                HrmsLeaveRolePermission::updateOrCreate(
+                    [
+                        'sub_institute_id' => $context['sub_institute_id'],
+                        'role_name'        => $role['role_name'],
+                    ],
+                    [
+                        'scope'              => $role['scope'],
+                        'approve_leave'      => filter_var($role['approve_leave'], FILTER_VALIDATE_BOOLEAN),
+                        'view_reports'       => filter_var($role['view_reports'], FILTER_VALIDATE_BOOLEAN),
+                        'configure_settings' => filter_var($role['configure_settings'], FILTER_VALIDATE_BOOLEAN),
+                        'bulk_operations'    => filter_var($role['bulk_operations'], FILTER_VALIDATE_BOOLEAN),
+                        'escalation_rights'  => filter_var($role['escalation_rights'], FILTER_VALIDATE_BOOLEAN),
+                        'user_management'    => filter_var($role['user_management'], FILTER_VALIDATE_BOOLEAN),
+                        'status'             => array_key_exists('status', $role)
+                            ? filter_var($role['status'], FILTER_VALIDATE_BOOLEAN)
+                            : true,
+                        'sort_order'         => (int) ($role['sort_order'] ?? $index + 1),
+                        'updated_by'         => $context['user_id'],
+                    ]
+                );
+            }
+        });
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Role permissions saved successfully',
+            'data'    => $this->resolveRoles($context)->map(fn ($role) => $this->transformRole($role))->values(),
+        ]);
+    }
+
+    private function resolveWorkflow(array $context): HrmsLeaveWorkflowSetting
+    {
+        return HrmsLeaveWorkflowSetting::firstOrCreate(
+            ['sub_institute_id' => $context['sub_institute_id']],
+            array_merge(HrmsLeaveWorkflowSetting::defaults(), ['created_by' => $context['user_id']])
+        );
+    }
+
+    private function resolveRoles(array $context)
+    {
+        $roles = HrmsLeaveRolePermission::where('sub_institute_id', $context['sub_institute_id'])
+            ->orderBy('sort_order')
+            ->get();
+
+        if ($roles->isNotEmpty()) {
+            return $roles;
+        }
+
+        foreach (HrmsLeaveRolePermission::defaults() as $role) {
+            HrmsLeaveRolePermission::create(array_merge($role, [
+                'sub_institute_id' => $context['sub_institute_id'],
+                'status'           => true,
+                'created_by'       => $context['user_id'],
+            ]));
+        }
+
+        return HrmsLeaveRolePermission::where('sub_institute_id', $context['sub_institute_id'])
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    private function transformWorkflow(HrmsLeaveWorkflowSetting $settings): array
+    {
+        return [
+            'id'                        => (int) $settings->id,
+            'reporting_manager_enabled' => (bool) $settings->reporting_manager_enabled,
+            'department_head_enabled'   => (bool) $settings->department_head_enabled,
+            'hr_enabled'                => (bool) $settings->hr_enabled,
+            'multi_level_enabled'       => (bool) $settings->multi_level_enabled,
+            'multi_level_count'         => (int) $settings->multi_level_count,
+            'escalation_enabled'        => (bool) $settings->escalation_enabled,
+            'escalation_time'           => (int) $settings->escalation_time,
+            'escalation_unit'           => $settings->escalation_unit,
+            'escalate_to'               => $settings->escalate_to,
+        ];
+    }
+
+    private function transformRole(HrmsLeaveRolePermission $role): array
+    {
+        return [
+            'id'                 => (int) $role->id,
+            'role_name'          => $role->role_name,
+            'scope'              => $role->scope,
+            'approve_leave'      => (bool) $role->approve_leave,
+            'view_reports'       => (bool) $role->view_reports,
+            'configure_settings' => (bool) $role->configure_settings,
+            'bulk_operations'    => (bool) $role->bulk_operations,
+            'escalation_rights'  => (bool) $role->escalation_rights,
+            'user_management'    => (bool) $role->user_management,
+            'status'             => (bool) $role->status,
+            'sort_order'         => (int) $role->sort_order,
+        ];
+    }
+}

--- a/app/Models/HRMS/HrmsLeaveRolePermission.php
+++ b/app/Models/HRMS/HrmsLeaveRolePermission.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models\HRMS;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class HrmsLeaveRolePermission extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'hrms_leave_role_permissions';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'approve_leave'      => 'boolean',
+        'view_reports'       => 'boolean',
+        'configure_settings' => 'boolean',
+        'bulk_operations'    => 'boolean',
+        'escalation_rights'  => 'boolean',
+        'user_management'    => 'boolean',
+        'status'             => 'boolean',
+        'sort_order'         => 'integer',
+    ];
+
+    public const PERMISSION_KEYS = [
+        'approve_leave',
+        'view_reports',
+        'configure_settings',
+        'bulk_operations',
+        'escalation_rights',
+        'user_management',
+    ];
+
+    /**
+     * Seeded on first read so an institute that has never configured roles still
+     * gets the standard leave hierarchy instead of an empty table.
+     */
+    public static function defaults(): array
+    {
+        return [
+            ['role_name' => 'Employee',          'scope' => 'Self',         'approve_leave' => false, 'view_reports' => true, 'configure_settings' => false, 'bulk_operations' => false, 'escalation_rights' => false, 'user_management' => false, 'sort_order' => 1],
+            ['role_name' => 'Reporting Manager', 'scope' => 'Team',         'approve_leave' => true,  'view_reports' => true, 'configure_settings' => false, 'bulk_operations' => false, 'escalation_rights' => false, 'user_management' => false, 'sort_order' => 2],
+            ['role_name' => 'Department Head',   'scope' => 'Department',   'approve_leave' => true,  'view_reports' => true, 'configure_settings' => true,  'bulk_operations' => false, 'escalation_rights' => false, 'user_management' => false, 'sort_order' => 3],
+            ['role_name' => 'HR Executive',      'scope' => 'Department',   'approve_leave' => true,  'view_reports' => true, 'configure_settings' => true,  'bulk_operations' => false, 'escalation_rights' => false, 'user_management' => false, 'sort_order' => 4],
+            ['role_name' => 'HR Manager',        'scope' => 'Organization', 'approve_leave' => true,  'view_reports' => true, 'configure_settings' => true,  'bulk_operations' => true,  'escalation_rights' => true,  'user_management' => true,  'sort_order' => 5],
+            ['role_name' => 'Administrator',     'scope' => 'Organization', 'approve_leave' => true,  'view_reports' => true, 'configure_settings' => true,  'bulk_operations' => true,  'escalation_rights' => true,  'user_management' => true,  'sort_order' => 6],
+            ['role_name' => 'Executive',         'scope' => 'Organization', 'approve_leave' => true,  'view_reports' => true, 'configure_settings' => true,  'bulk_operations' => true,  'escalation_rights' => true,  'user_management' => false, 'sort_order' => 7],
+        ];
+    }
+}

--- a/app/Models/HRMS/HrmsLeaveWorkflowSetting.php
+++ b/app/Models/HRMS/HrmsLeaveWorkflowSetting.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models\HRMS;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class HrmsLeaveWorkflowSetting extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'hrms_leave_workflow_settings';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'reporting_manager_enabled' => 'boolean',
+        'department_head_enabled'   => 'boolean',
+        'hr_enabled'                => 'boolean',
+        'multi_level_enabled'       => 'boolean',
+        'escalation_enabled'        => 'boolean',
+        'multi_level_count'         => 'integer',
+        'escalation_time'           => 'integer',
+    ];
+
+    /** Values used when an institute has never saved a workflow. */
+    public static function defaults(): array
+    {
+        return [
+            'reporting_manager_enabled' => true,
+            'department_head_enabled'   => true,
+            'hr_enabled'                => false,
+            'multi_level_enabled'       => false,
+            'multi_level_count'         => 2,
+            'escalation_enabled'        => true,
+            'escalation_time'           => 24,
+            'escalation_unit'           => 'hours',
+            'escalate_to'               => 'hr',
+        ];
+    }
+}

--- a/app/Services/Leave/LeaveAnalyticsService.php
+++ b/app/Services/Leave/LeaveAnalyticsService.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace App\Services\Leave;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use function App\Helpers\countDays;
+
+/**
+ * Single home for the Leave Management business rules that were previously
+ * duplicated across LeaveSummaryReportController, LeaveReportController and
+ * LeaveAuthorisationController:
+ *
+ *  - the leave year is April 1 {Y} to March 31 {Y+1}
+ *  - entitlement comes from hrms_leave_allocation, employee rows overriding
+ *    department rows for Casual (LTY001) and Earned (LTY009) leave, and only
+ *    while the employee is still inside probation_period_to
+ *  - 'approved' and 'pending' consume balance; 'approved_lwp' accrues into a
+ *    synthetic "Leave Without Pay" bucket instead
+ *  - entitlement is capped at 180.00 days
+ */
+class LeaveAnalyticsService
+{
+    public const MAX_OPENING_LEAVE = 180.00;
+    public const LWP_BUCKET = 'Leave Without Pay';
+
+    /** Statuses that draw down the balance. */
+    public const CONSUMING_STATUSES = ['approved', 'pending'];
+
+    public function leaveYearBounds(int $year): array
+    {
+        return [$year . '-04-01', ($year + 1) . '-03-31'];
+    }
+
+    /** Active leave types for the institute, in display order. */
+    public function leaveTypes(int $subInstituteId)
+    {
+        return DB::table('hrms_leave_types')
+            ->where('sub_institute_id', $subInstituteId)
+            ->where('status', 1)
+            ->whereNull('deleted_at')
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    /**
+     * Resolve the numeric primary key of a leave type from its LTY code.
+     * The legacy report hardcoded 1 and 9; falling back to those keeps parity
+     * on the standard dataset without breaking institutes that differ.
+     */
+    public function leaveTypeIdByCode(int $subInstituteId, string $code, int $fallback): int
+    {
+        $row = DB::table('hrms_leave_types')
+            ->where('sub_institute_id', $subInstituteId)
+            ->where('leave_type_id', $code)
+            ->whereNull('deleted_at')
+            ->first();
+
+        return (int) ($row->id ?? $fallback);
+    }
+
+    /**
+     * Days consumed per leave type, per employee, inside the leave year.
+     *
+     * @return array<string, array<int, float>> [leave_type_name][user_id] => days
+     */
+    public function consumedByType(int $subInstituteId, int $year, ?int $departmentId = null, ?int $employeeId = null): array
+    {
+        [$from, $to] = $this->leaveYearBounds($year);
+
+        $rows = DB::table('hrms_emp_leaves as hel')
+            ->join('tbluser as u', 'u.id', '=', 'hel.user_id')
+            ->leftJoin('hrms_leave_types as hlt', function ($join) use ($subInstituteId) {
+                $join->on('hlt.id', '=', 'hel.leave_type_id')
+                     ->where('hlt.sub_institute_id', '=', $subInstituteId);
+            })
+            ->selectRaw('hel.user_id, hel.from_date, hel.to_date, hel.day_type, hel.status, hlt.leave_type')
+            ->where('hel.sub_institute_id', $subInstituteId)
+            ->whereNull('hel.deleted_at')
+            ->where('u.status', 1)
+            ->where('hel.from_date', '>=', $from)
+            ->where('hel.to_date', '<=', $to)
+            ->whereIn('hel.status', array_merge(self::CONSUMING_STATUSES, ['approved_lwp']))
+            ->when($departmentId, fn ($q) => $q->where('u.department_id', $departmentId))
+            ->when($employeeId, fn ($q) => $q->where('hel.user_id', $employeeId))
+            ->get();
+
+        $consumed = [];
+
+        foreach ($rows as $row) {
+            $bucket = $row->status === 'approved_lwp'
+                ? self::LWP_BUCKET
+                : ($row->leave_type ?: 'Unassigned');
+
+            $days = (float) countDays($row->from_date, $row->to_date ?: $row->from_date, $row->day_type ?: 1, '');
+
+            $userId = (int) $row->user_id;
+            $consumed[$bucket][$userId] = round(($consumed[$bucket][$userId] ?? 0) + $days, 2);
+        }
+
+        return $consumed;
+    }
+
+    /**
+     * Entitlement per leave type, per employee, for the leave year.
+     *
+     * @return array<string, array<int, float>> [leave_type_name][user_id] => days
+     */
+    public function entitlementByType(int $subInstituteId, int $year, ?int $departmentId = null, ?int $employeeId = null): array
+    {
+        $leaveTypes = $this->leaveTypes($subInstituteId);
+
+        if ($leaveTypes->isEmpty()) {
+            return [];
+        }
+
+        $employees = DB::table('tbluser')
+            ->select('id', 'department_id', 'probation_period_to')
+            ->where('sub_institute_id', $subInstituteId)
+            ->where('status', 1)
+            ->when($departmentId, fn ($q) => $q->where('department_id', $departmentId))
+            ->when($employeeId, fn ($q) => $q->where('id', $employeeId))
+            ->get();
+
+        if ($employees->isEmpty()) {
+            return [];
+        }
+
+        $earnedTypeId = $this->leaveTypeIdByCode($subInstituteId, 'LTY009', 9);
+        $casualTypeId = $this->leaveTypeIdByCode($subInstituteId, 'LTY001', 1);
+
+        // One pass over the allocation table instead of 3 queries per employee per type.
+        $allocations = DB::table('hrms_leave_allocation')
+            ->where('sub_institute_id', $subInstituteId)
+            ->where('year', $year)
+            ->whereNull('deleted_at')
+            ->get();
+
+        $departmentAllocation = [];  // [leave_type_id][department_id] => value
+        $employeeAllocation   = [];  // [leave_type_id][employee_id]   => value
+
+        foreach ($allocations as $allocation) {
+            $typeId = (int) $allocation->leave_type_id;
+
+            if (empty($allocation->employee_id)) {
+                $departmentAllocation[$typeId][(int) $allocation->department_id] = (float) $allocation->value;
+            } else {
+                $employeeAllocation[$typeId][(int) $allocation->employee_id] = (float) $allocation->value;
+            }
+        }
+
+        $today = Carbon::today();
+        $entitlement = [];
+
+        foreach ($employees as $employee) {
+            $userId       = (int) $employee->id;
+            $deptId       = (int) ($employee->department_id ?? 0);
+            $onProbation  = $employee->probation_period_to
+                && Carbon::parse($employee->probation_period_to)->greaterThan($today);
+
+            $employeeEarned = $employeeAllocation[$earnedTypeId][$userId] ?? 0;
+            $employeeCasual = $employeeAllocation[$casualTypeId][$userId] ?? 0;
+
+            foreach ($leaveTypes as $leaveType) {
+                $typeId       = (int) $leaveType->id;
+                $typeCode     = $leaveType->leave_type_id ?? '';
+                $departmental = $departmentAllocation[$typeId][$deptId] ?? 0;
+
+                $value = $departmental;
+
+                if ($typeCode === 'LTY009') {
+                    // Earned: employee allocation replaces the department grant during
+                    // probation, and tops it up afterwards.
+                    $value = ($employeeEarned > 0 && $onProbation)
+                        ? $employeeEarned
+                        : $departmental + $employeeEarned;
+                }
+
+                if ($typeCode === 'LTY001' && $employeeCasual > 0 && $onProbation) {
+                    $value = $employeeCasual;
+                }
+
+                $entitlement[$leaveType->leave_type][$userId] = round(min($value, self::MAX_OPENING_LEAVE), 2);
+            }
+        }
+
+        return $entitlement;
+    }
+
+    /**
+     * Total / used / remaining per leave type for one employee.
+     *
+     * @return array{leave_types: array<int, array<string, mixed>>, overall: array<string, float>}
+     */
+    public function balancesForEmployee(int $subInstituteId, int $year, int $employeeId): array
+    {
+        $employee = DB::table('tbluser')->select('department_id')->where('id', $employeeId)->first();
+        $departmentId = $employee->department_id ?? null;
+
+        $entitlement = $this->entitlementByType($subInstituteId, $year, $departmentId ? (int) $departmentId : null, $employeeId);
+        $consumed    = $this->consumedByType($subInstituteId, $year, null, $employeeId);
+
+        $names = array_unique(array_merge(array_keys($entitlement), array_keys($consumed)));
+        sort($names);
+
+        $rows = [];
+        $overallTotal = $overallUsed = 0.0;
+
+        foreach ($names as $name) {
+            $total = (float) ($entitlement[$name][$employeeId] ?? 0);
+            $used  = (float) ($consumed[$name][$employeeId] ?? 0);
+            // LWP has no entitlement, so it can never show a remaining balance.
+            $remaining = $total > 0 ? round($total - $used, 2) : 0.0;
+
+            $rows[] = [
+                'leave_type' => $name,
+                'total'      => round($total, 2),
+                'used'       => round($used, 2),
+                'remaining'  => $remaining,
+            ];
+
+            $overallTotal += $total;
+            $overallUsed  += $used;
+        }
+
+        return [
+            'leave_types' => $rows,
+            'overall'     => [
+                'total'     => round($overallTotal, 2),
+                'used'      => round($overallUsed, 2),
+                'remaining' => round(max($overallTotal - $overallUsed, 0), 2),
+            ],
+        ];
+    }
+
+    /** Base query for every request-list and aggregate endpoint. */
+    public function requestsQuery(int $subInstituteId, int $year)
+    {
+        [$from, $to] = $this->leaveYearBounds($year);
+
+        return DB::table('hrms_emp_leaves as hel')
+            ->join('tbluser as u', 'u.id', '=', 'hel.user_id')
+            ->leftJoin('hrms_leave_types as hlt', function ($join) use ($subInstituteId) {
+                $join->on('hlt.id', '=', 'hel.leave_type_id')
+                     ->where('hlt.sub_institute_id', '=', $subInstituteId);
+            })
+            ->leftJoin('hrms_departments as hd', 'hd.id', '=', 'u.department_id')
+            ->leftJoin('hrms_job_titles as hjt', 'hjt.id', '=', 'u.jobtitle_id')
+            ->where('hel.sub_institute_id', $subInstituteId)
+            ->whereNull('hel.deleted_at')
+            ->where('hel.from_date', '>=', $from)
+            ->where('hel.to_date', '<=', $to);
+    }
+
+    /** Number of days a single request represents. */
+    public function requestDays(?string $fromDate, ?string $toDate, $dayType): float
+    {
+        if (!$fromDate) {
+            return 0.0;
+        }
+
+        return round((float) countDays($fromDate, $toDate ?: $fromDate, $dayType ?: 1, ''), 2);
+    }
+
+    /** "3 days" / "Half Day" for display. */
+    public function durationLabel(float $days): string
+    {
+        if ($days <= 0) {
+            return '—';
+        }
+
+        if ($days == 0.5) {
+            return 'Half Day';
+        }
+
+        $formatted = fmod($days, 1) == 0 ? (string) (int) $days : (string) $days;
+
+        return $formatted . ' day' . ($days > 1 ? 's' : '');
+    }
+}

--- a/database/migrations/2026_07_25_100100_create_hrms_leave_workflow_settings_table.php
+++ b/database/migrations/2026_07_25_100100_create_hrms_leave_workflow_settings_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Approval workflow configuration for the Leave Management module.
+     * One row per sub_institute_id.
+     */
+    public function up(): void
+    {
+        Schema::create('hrms_leave_workflow_settings', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+
+            $table->boolean('reporting_manager_enabled')->default(true);
+            $table->boolean('department_head_enabled')->default(true);
+            $table->boolean('hr_enabled')->default(false);
+            $table->boolean('multi_level_enabled')->default(false);
+            $table->unsignedTinyInteger('multi_level_count')->default(2);
+
+            $table->boolean('escalation_enabled')->default(true);
+            $table->unsignedInteger('escalation_time')->default(24);
+            $table->enum('escalation_unit', ['hours', 'days'])->default('hours');
+            $table->enum('escalate_to', ['department-head', 'hr', 'admin'])->default('hr');
+
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique('sub_institute_id', 'hrms_leave_workflow_settings_institute_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hrms_leave_workflow_settings');
+    }
+};

--- a/database/migrations/2026_07_25_100200_create_hrms_leave_role_permissions_table.php
+++ b/database/migrations/2026_07_25_100200_create_hrms_leave_role_permissions_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Role based permission matrix for the Leave Management module.
+     * One row per (sub_institute_id, role_name).
+     */
+    public function up(): void
+    {
+        Schema::create('hrms_leave_role_permissions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('role_name', 100);
+            $table->enum('scope', ['Self', 'Team', 'Department', 'Organization'])->default('Self');
+
+            $table->boolean('approve_leave')->default(false);
+            $table->boolean('view_reports')->default(false);
+            $table->boolean('configure_settings')->default(false);
+            $table->boolean('bulk_operations')->default(false);
+            $table->boolean('escalation_rights')->default(false);
+            $table->boolean('user_management')->default(false);
+
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->boolean('status')->default(true);
+
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['sub_institute_id', 'role_name'], 'hrms_leave_role_permissions_institute_role_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hrms_leave_role_permissions');
+    }
+};

--- a/database/migrations/2026_07_25_100300_add_carry_forward_to_hrms_leave_types_table.php
+++ b/database/migrations/2026_07_25_100300_add_carry_forward_to_hrms_leave_types_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Carry forward has no home anywhere in the schema today - the annual quota
+     * itself stays in hrms_leave_allocation (per department / employee / year).
+     */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('hrms_leave_types', 'carry_forward')) {
+            Schema::table('hrms_leave_types', function (Blueprint $table) {
+                $table->boolean('carry_forward')->default(false)->after('sort_order');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('hrms_leave_types', 'carry_forward')) {
+            Schema::table('hrms_leave_types', function (Blueprint $table) {
+                $table->dropColumn('carry_forward');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_25_100400_extend_hrms_emp_leaves_status_enum.php
+++ b/database/migrations/2026_07_25_100400_extend_hrms_emp_leaves_status_enum.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The original migration declared enum('approved','pending','rejected') but the
+     * controllers have always written 'cancelled' and 'approved_lwp' as well. On a
+     * strict-mode connection those writes fail, so widen the column to match reality.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('hrms_emp_leaves')) {
+            return;
+        }
+
+        DB::statement("ALTER TABLE `hrms_emp_leaves` MODIFY `status` ENUM('approved','pending','rejected','cancelled','approved_lwp','sent_back') NULL");
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('hrms_emp_leaves')) {
+            return;
+        }
+
+        DB::statement("UPDATE `hrms_emp_leaves` SET `status` = 'pending' WHERE `status` IN ('cancelled','approved_lwp','sent_back')");
+        DB::statement("ALTER TABLE `hrms_emp_leaves` MODIFY `status` ENUM('approved','pending','rejected') NULL");
+    }
+};

--- a/database/migrations/2026_07_25_100500_add_description_to_hrms_holidays_table.php
+++ b/database/migrations/2026_07_25_100500_add_description_to_hrms_holidays_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The Holiday Calendar screen already captures an optional description;
+     * hrms_holidays had nowhere to put it.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('hrms_holidays', 'description')) {
+            Schema::table('hrms_holidays', function (Blueprint $table) {
+                $table->string('description', 500)->nullable()->after('holiday_name');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('hrms_holidays', 'description')) {
+            Schema::table('hrms_holidays', function (Blueprint $table) {
+                $table->dropColumn('description');
+            });
+        }
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,6 +67,17 @@ use App\Http\Controllers\HRMS\DepartmentSkillController;
 use App\Http\Controllers\HRTemplates\TemplateController;
 use App\Http\Controllers\NewsletterController;
 use App\Http\Controllers\CareerJourneyController;
+use App\Http\Controllers\Api\Leave\LeaveDashboardController;
+use App\Http\Controllers\Api\Leave\LeaveRequestApiController;
+use App\Http\Controllers\Api\Leave\LeaveOptionsController;
+use App\Http\Controllers\Api\Leave\LeaveReportApiController;
+use App\Http\Controllers\Api\Leave\LeaveTypeApiController;
+use App\Http\Controllers\Api\Leave\HolidayApiController;
+use App\Http\Controllers\Api\Leave\LeaveWorkflowApiController;
+use App\Http\Controllers\Api\Leave\LeaveDistributionApiController;
+use App\Http\Controllers\Api\Attendance\AttendanceTrackingApiController;
+use App\Http\Controllers\Api\Attendance\AttendanceReportApiController;
+use App\Http\Controllers\Api\Attendance\AttendanceDashboardApiController;
 
 
 Route::post('/send-otp', [signupOtpController::class, 'sendOtp']);
@@ -156,6 +167,95 @@ Route::get('/KPI-HRITDashboard', [AttendanceApiController::class, 'KPI']);
 
 Route::get('/jobroles-by-department', [JobroleApiController::class, 'getDepartmentWise']);
 Route::get('/leave-distribution', [LeaveDistribution::class, 'leaveDistribution']);
+
+/*
+|--------------------------------------------------------------------------
+| Leave Management API
+|--------------------------------------------------------------------------
+| Token authenticated endpoints backing the Next.js Leave Management module
+| (Dashboard, Leave Requests, Reports, Configuration). Every endpoint is
+| scoped by sub_institute_id and the April-March leave year - see
+| App\Http\Controllers\Api\Leave\Concerns\ResolvesLeaveContext.
+*/
+Route::prefix('leave')->group(function () {
+    // Dashboard
+    Route::get('/dashboard', [LeaveDashboardController::class, 'index']);
+    Route::get('/trend', [LeaveDashboardController::class, 'trend']);
+    Route::get('/department-summary', [LeaveDashboardController::class, 'departmentSummary']);
+    Route::get('/type-distribution', [LeaveDashboardController::class, 'typeDistribution']);
+    Route::get('/holidays/upcoming', [LeaveDashboardController::class, 'upcomingHolidays']);
+
+    // Shared lookups
+    Route::get('/options', [LeaveOptionsController::class, 'index']);
+    Route::get('/balances', [LeaveOptionsController::class, 'balances']);
+
+    // Leave requests
+    Route::get('/requests', [LeaveRequestApiController::class, 'index']);
+    Route::post('/requests', [LeaveRequestApiController::class, 'store']);
+    Route::post('/requests/bulk-decision', [LeaveRequestApiController::class, 'bulkDecision']);
+    Route::get('/requests/{id}', [LeaveRequestApiController::class, 'show'])->whereNumber('id');
+    Route::post('/requests/{id}/decision', [LeaveRequestApiController::class, 'decision'])->whereNumber('id');
+    Route::delete('/requests/{id}', [LeaveRequestApiController::class, 'destroy'])->whereNumber('id');
+
+    // Reports
+    Route::get('/reports/summary', [LeaveReportApiController::class, 'summary']);
+    Route::get('/reports/register', [LeaveReportApiController::class, 'register']);
+    Route::get('/reports/balance', [LeaveReportApiController::class, 'balance']);
+
+    // Configuration - leave types
+    Route::get('/leave-types', [LeaveTypeApiController::class, 'index']);
+    Route::post('/leave-types', [LeaveTypeApiController::class, 'store']);
+    Route::put('/leave-types/{id}', [LeaveTypeApiController::class, 'store'])->whereNumber('id');
+    Route::patch('/leave-types/{id}/status', [LeaveTypeApiController::class, 'toggleStatus'])->whereNumber('id');
+    Route::delete('/leave-types/{id}', [LeaveTypeApiController::class, 'destroy'])->whereNumber('id');
+
+    // Configuration - holidays and weekly off pattern
+    Route::get('/holidays', [HolidayApiController::class, 'index']);
+    Route::post('/holidays', [HolidayApiController::class, 'store']);
+    Route::put('/holidays/{id}', [HolidayApiController::class, 'update'])->whereNumber('id');
+    Route::delete('/holidays/{id}', [HolidayApiController::class, 'destroy']);
+    Route::get('/weekdays', [HolidayApiController::class, 'weekdays']);
+    Route::post('/weekdays', [HolidayApiController::class, 'storeWeekdays']);
+
+    // Configuration - approval workflow and role access
+    Route::get('/workflow', [LeaveWorkflowApiController::class, 'workflow']);
+    Route::put('/workflow', [LeaveWorkflowApiController::class, 'saveWorkflow']);
+    Route::get('/roles', [LeaveWorkflowApiController::class, 'roles']);
+    Route::put('/roles', [LeaveWorkflowApiController::class, 'saveRoles']);
+
+    // Distribution - new controller, GET /api/leave-distribution above is
+    // untouched and still serves its existing consumers.
+    Route::get('/distribution', [LeaveDistributionApiController::class, 'index']);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Attendance Management API
+|--------------------------------------------------------------------------
+| Token authenticated, session free endpoints backing the Next.js Attendance
+| Management module (Attendance Tracking + Attendance Reports).
+|
+| These are additive: the legacy web routes hrms-attendance,
+| hrms-attendance-in-time/store, hrms-attendance-out-time/store,
+| hrms-attendance-report and get-employees-list still point at
+| App\Http\Controllers\HRMS\HrmsController, and /api/attendance-weekly plus
+| /api/KPI-HRITDashboard still point at
+| App\Http\Controllers\Api\HRITDashboard\AttendanceApiController.
+*/
+Route::prefix('attendance')->group(function () {
+    // Self service - my attendance calendar and punches
+    Route::get('/my-attendance', [AttendanceTrackingApiController::class, 'myAttendance']);
+    Route::post('/punch-in', [AttendanceTrackingApiController::class, 'punchIn']);
+    Route::post('/punch-out', [AttendanceTrackingApiController::class, 'punchOut']);
+
+    // Report lookups
+    Route::get('/report-filters', [AttendanceReportApiController::class, 'filters']);
+    Route::get('/employees', [AttendanceReportApiController::class, 'employees']);
+
+    // Dashboard analytics (department + employee scoped)
+    Route::get('/weekly-summary', [AttendanceDashboardApiController::class, 'weeklySummary']);
+    Route::get('/kpi', [AttendanceDashboardApiController::class, 'kpi']);
+});
 
 
 


### PR DESCRIPTION
Add comprehensive API endpoints for leave management and attendance tracking to support the Next.js module. This includes dashboard summaries, leave requests, reporting, configuration for leave types, and holiday management.

Key changes:
- Added new API controllers for Leave and Attendance modules.
- Implemented new service layer for leave logic.
- Added database migrations for leave workflow settings, role permissions, carry-forward functionality, and holiday enhancements.
- Registered new routes in `api.php` under `/leave` and attendance prefixes.
- Added new HRMS models for leave workflow and permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Leave Management APIs for requests, approvals, dashboards, reports, balances, leave types, holidays, weekly offs, workflows, and role permissions.
  * Added Attendance Management APIs for self-service calendars, punch in/out, reports, weekly summaries, and KPIs.
  * Added leave type carry-forward support and expanded leave statuses.
  * Added configurable approval workflows and role-based permissions.
* **Bug Fixes**
  * Improved leave filtering, bulk decisions, balance calculations, and date-range handling.
  * Added validation and duplicate prevention for leave and holiday records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->