### PR TITLE
feat(competency): add full backend competency management system

### DIFF
--- a/app/Http/Controllers/Api/Competency/AssessmentController.php
+++ b/app/Http/Controllers/Api/Competency/AssessmentController.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * CRUD for competency assessments (s_competency_assessments). Backs the
+ * "Launch Assessment" quick action and the Assessment Workspace screen.
+ */
+class AssessmentController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $perPage = min(max((int) $request->input('per_page', 15), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('status', $status);
+        }
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('title', 'like', "%{$search}%");
+        }
+
+        $total = (clone $query)->count();
+        $rows = $query->orderByDesc('id')->forPage($page, $perPage)->get();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Assessments fetched successfully',
+            'data'       => $rows,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title'         => 'required|string|max:191',
+            'framework_id'  => 'nullable|integer',
+            'cycle_id'      => 'nullable|integer',
+            'user_id'       => 'nullable|integer',
+            'assessor_id'   => 'nullable|integer',
+            'department_id' => 'nullable|integer',
+            'jobrole'       => 'nullable|string|max:191',
+            'status'        => 'nullable|in:open,in_progress,completed,overdue',
+            'due_date'      => 'nullable|date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table('s_competency_assessments')->insertGetId([
+            'sub_institute_id' => $context['sub_institute_id'],
+            'title'            => $request->input('title'),
+            'framework_id'     => $request->input('framework_id'),
+            'cycle_id'         => $request->input('cycle_id'),
+            'user_id'          => $request->input('user_id'),
+            'assessor_id'      => $request->input('assessor_id'),
+            'department_id'    => $request->input('department_id'),
+            'jobrole'          => $request->input('jobrole'),
+            'status'           => $request->input('status', 'open'),
+            'due_date'         => $request->input('due_date'),
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'launched_assessment',
+            'Launched assessment "' . $request->input('title') . '"',
+            'assessment',
+            $id,
+            $request->input('title')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Assessment created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $existing = DB::table('s_competency_assessments')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Assessment not found'], 404);
+        }
+
+        DB::table('s_competency_assessments')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_assessment',
+            'Deleted assessment "' . $existing->title . '"',
+            'assessment',
+            (int) $id,
+            $existing->title
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Assessment deleted successfully']);
+    }
+}

--- a/app/Http/Controllers/Api/Competency/AssessmentCycleController.php
+++ b/app/Http/Controllers/Api/Competency/AssessmentCycleController.php
@@ -1,0 +1,1037 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ManagesCompetencySettings;
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class AssessmentCycleController extends Controller
+{
+    use ResolvesCompetencyContext;
+    use ManagesCompetencySettings;
+
+    /**
+     * The "View Configuration" panel's editable settings, with the defaults a
+     * tenant that has never saved them gets. Keys are the allowed set.
+     */
+    private const ASSESSMENT_DEFAULTS = [
+        'self_assessment_required' => true,
+        'manager_review_required'  => true,
+        'calibration_required'     => true,
+        // Who signs a completed assessment off: manager | hr | both
+        'approval_chain'           => 'manager',
+        // Default window for a new campaign, in days
+        'default_duration_days'    => 30,
+        // Reminder cadence in days before the due date (0 = off)
+        'reminder_days_before'     => 7,
+        // Allow a reviewer to change a rating during calibration
+        'allow_rating_override'    => true,
+        // Show the employee their manager's rating once reviewed
+        'publish_results'          => false,
+    ];
+
+    private const APPROVAL_CHAINS = ['manager', 'hr', 'both'];
+
+    /** What a campaign with no explicit type reads as. */
+    private const DEFAULT_CYCLE_TYPE = 'Self + Manager';
+
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $query = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            if ($status === 'progress') {
+                $query->whereIn('status', ['active', 'scheduled']);
+            } else {
+                $query->where('status', $status);
+            }
+        }
+
+        $cycles = $query->orderByDesc('id')->get();
+
+        $cycleIds = $cycles->pluck('id')->toArray();
+        $assessments = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereIn('cycle_id', $cycleIds)
+            ->whereNull('deleted_at')
+            ->select('cycle_id', 'status')
+            ->get();
+
+        $stats = [];
+        foreach ($assessments as $a) {
+            if (!isset($stats[$a->cycle_id])) {
+                $stats[$a->cycle_id] = ['total' => 0, 'completed' => 0];
+            }
+            $stats[$a->cycle_id]['total']++;
+            if ($a->status === 'completed') {
+                $stats[$a->cycle_id]['completed']++;
+            }
+        }
+
+        $data = $cycles->map(function ($c) use ($stats) {
+            $total = $stats[$c->id]['total'] ?? 0;
+            $completed = $stats[$c->id]['completed'] ?? 0;
+            $completion = $total > 0 ? round(($completed / $total) * 100) : 0;
+            
+            $frontendStatus = 'In Progress';
+            if ($c->status === 'closed') {
+                $frontendStatus = 'Completed';
+            }
+
+            return [
+                'id' => (string)$c->id,
+                'name' => $c->name,
+                // Real column now; falls back to what this used to hardcode so
+                // campaigns created before the column read exactly as before.
+                'type' => $c->type ?: self::DEFAULT_CYCLE_TYPE,
+                'participants' => $total,
+                'completion' => $completion,
+                'status' => $frontendStatus,
+                'date' => $c->end_date ? date('d M Y', strtotime($c->end_date)) : 'N/A'
+            ];
+        });
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Campaigns fetched successfully',
+            'data' => $data
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:191',
+            'type' => 'nullable|string',
+            'start_date' => 'nullable|date',
+            'end_date' => 'nullable|date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 0,
+                'message' => $validator->errors()->first(),
+                'errors' => $validator->errors()
+            ], 422);
+        }
+
+        $id = DB::table('s_competency_assessment_cycles')->insertGetId([
+            'sub_institute_id' => $context['sub_institute_id'],
+            'name' => $request->input('name'),
+            'start_date' => $request->input('start_date'),
+            'end_date' => $request->input('end_date'),
+            'status' => 'active',
+            'created_by' => $context['user_id'],
+            'updated_by' => $context['user_id'],
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'created_assessment_cycle',
+            'Created assessment campaign "' . $request->input('name') . '"',
+            'assessment_cycle',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Campaign created successfully',
+            'data' => ['id' => $id]
+        ], 201);
+    }
+
+    public function metrics(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $sid = $context['sub_institute_id'];
+
+        $activeCampaigns = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereIn('status', ['active', 'scheduled'])
+            ->count();
+
+        $assessments = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->select('status', 'review_status')
+            ->get();
+
+        $totalAssessments = $assessments->count();
+        $completedAssessments = $assessments->where('status', 'completed')->count();
+
+        $overallCompletionPercent = $totalAssessments > 0 ? round(($completedAssessments / $totalAssessments) * 100) : 0;
+
+        // Manager ratings pending = completed but no manager/calibration review yet.
+        $pendingManagerRatings = $assessments
+            ->where('status', 'completed')
+            ->whereNull('review_status')
+            ->count();
+
+        // Calibration queue = completed and flagged for review.
+        $pendingCalibration = $assessments
+            ->where('status', 'completed')
+            ->where('review_status', 'pending_review')
+            ->count();
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Metrics fetched successfully',
+            'data' => [
+                'active_campaigns' => $activeCampaigns,
+                'overall_completion_percent' => $overallCompletionPercent,
+                'completed_assessments' => $completedAssessments,
+                'total_assessments' => $totalAssessments,
+                'pending_manager_ratings' => $pendingManagerRatings,
+                'pending_calibration' => $pendingCalibration
+            ]
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Workspace top-tab lists (Participant Ratings / Calibration /
+     * Approvals / Closed Campaigns) — all over s_competency_assessments.
+     * ----------------------------------------------------------------- */
+
+    /** All participant assessments across every campaign. */
+    public function participantRatings(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = $this->assessmentBase($context['sub_institute_id'])
+            ->orderByDesc('a.id')->limit(300)->get();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Participant ratings fetched successfully',
+            'data'    => $rows->map(fn ($a) => $this->mapAssessment($a))->all(),
+        ]);
+    }
+
+    /** Completed assessments flagged for calibration review. */
+    public function calibration(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = $this->assessmentBase($context['sub_institute_id'])
+            ->where('a.status', 'completed')
+            ->where('a.review_status', 'pending_review')
+            ->orderByDesc('a.id')->limit(300)->get();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Calibration queue fetched successfully',
+            'data'    => $rows->map(fn ($a) => $this->mapAssessment($a))->all(),
+        ]);
+    }
+
+    /** Completed assessments awaiting manager approval / sign-off. */
+    public function approvals(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = $this->assessmentBase($context['sub_institute_id'])
+            ->where('a.status', 'completed')
+            ->whereNull('a.review_status')
+            ->orderByDesc('a.id')->limit(300)->get();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Approvals queue fetched successfully',
+            'data'    => $rows->map(fn ($a) => $this->mapAssessment($a))->all(),
+        ]);
+    }
+
+    /** Closed campaigns (assessment cycles) with completion stats. */
+    public function closed(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $cycles = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('status', 'closed')
+            ->orderByDesc('id')->get();
+
+        $cycleIds = $cycles->pluck('id')->toArray();
+        $assessments = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $sid)
+            ->whereIn('cycle_id', $cycleIds ?: [0])
+            ->whereNull('deleted_at')
+            ->select('cycle_id', 'status')->get();
+
+        $stats = [];
+        foreach ($assessments as $a) {
+            $stats[$a->cycle_id] ??= ['total' => 0, 'completed' => 0];
+            $stats[$a->cycle_id]['total']++;
+            if ($a->status === 'completed') {
+                $stats[$a->cycle_id]['completed']++;
+            }
+        }
+
+        $data = $cycles->map(function ($c) use ($stats) {
+            $total = $stats[$c->id]['total'] ?? 0;
+            $completed = $stats[$c->id]['completed'] ?? 0;
+            return [
+                'id'           => (string) $c->id,
+                'name'         => $c->name,
+                'type'         => 'Self + Manager',
+                'participants' => $total,
+                'completion'   => $total > 0 ? round(($completed / $total) * 100) : 0,
+                'status'       => 'Completed',
+                'start_date'   => $c->start_date ? date('d M Y', strtotime($c->start_date)) : null,
+                'date'         => $c->end_date ? date('d M Y', strtotime($c->end_date)) : 'N/A',
+            ];
+        });
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Closed campaigns fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /** Approve / calibrate one assessment (sets review_status = reviewed). */
+    public function reviewAssessment(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'action' => 'required|in:approve,calibrate,reject',
+        ]);
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first(), 'errors' => $validator->errors()], 422);
+        }
+
+        $assessment = DB::table('s_competency_assessments')
+            ->where('id', $id)->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+        if (!$assessment) {
+            return response()->json(['status' => 0, 'message' => 'Assessment not found'], 404);
+        }
+
+        $action = $request->input('action');
+        $reviewStatus = $action === 'reject' ? 'pending_review' : 'reviewed';
+
+        DB::table('s_competency_assessments')->where('id', $id)->update([
+            'review_status' => $reviewStatus,
+            'updated_by'    => $context['user_id'],
+            'updated_at'    => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            $action . '_assessment',
+            ucfirst($action) . ' assessment "' . $assessment->title . '"',
+            'assessment',
+            (int) $id,
+            $assessment->title,
+            $this->diffChanges($assessment, ['review_status' => $reviewStatus], ['review_status' => 'Review Status'])
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Assessment ' . $action . 'd successfully']);
+    }
+
+    /* ----------------------------------------------------------------- */
+
+    private function assessmentBase(int $sid)
+    {
+        return DB::table('s_competency_assessments as a')
+            ->leftJoin('tbluser as u', 'a.user_id', '=', 'u.id')
+            ->leftJoin('s_competency_assessment_cycles as c', 'a.cycle_id', '=', 'c.id')
+            ->where('a.sub_institute_id', $sid)
+            ->whereNull('a.deleted_at')
+            ->select(
+                'a.id as assessment_id',
+                'a.user_id',
+                'a.jobrole',
+                'a.status',
+                'a.review_status',
+                'a.score',
+                'a.completed_at',
+                'a.due_date',
+                'u.first_name',
+                'u.last_name',
+                'u.employee_no',
+                'c.name as cycle_name'
+            );
+    }
+
+    private function mapAssessment($a): array
+    {
+        $fname = $a->first_name ?: 'Unknown';
+        $lname = $a->last_name ?: '';
+        $self = in_array($a->status, ['completed', 'overdue'], true);
+        $manager = $a->review_status === 'reviewed';
+
+        return [
+            'assessment_id' => (string) $a->assessment_id,
+            'name'          => trim($fname . ' ' . $lname),
+            'initials'      => strtoupper(substr($fname, 0, 1) . substr($lname, 0, 1)),
+            'emp_id'        => $a->employee_no ?: '',
+            'role'          => $a->jobrole ?: 'N/A',
+            'campaign'      => $a->cycle_name ?: '—',
+            'self'          => $self,
+            'manager'       => $manager,
+            'score'         => $a->score !== null ? (float) $a->score : null,
+            'status'        => $a->status,
+            'review_status' => $a->review_status,
+            'date'          => $a->completed_at
+                ? date('d M Y', strtotime($a->completed_at))
+                : ($a->due_date ? date('d M Y', strtotime($a->due_date)) : null),
+        ];
+    }
+
+    public function participants(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $sid = $context['sub_institute_id'];
+
+        $assessments = DB::table('s_competency_assessments as a')
+            ->leftJoin('tbluser as u', 'a.user_id', '=', 'u.id')
+            ->where('a.sub_institute_id', $sid)
+            ->where('a.cycle_id', $id)
+            ->whereNull('a.deleted_at')
+            ->select(
+                'a.id as assessment_id',
+                'a.user_id',
+                'a.jobrole',
+                'a.status',
+                'a.review_status',
+                'a.completed_at',
+                'u.first_name',
+                'u.last_name',
+                'u.employee_no'
+            )
+            ->get();
+
+        $data = $assessments->map(function ($a) {
+            $fname = $a->first_name ?: 'Unknown';
+            $lname = $a->last_name ?: '';
+            $initials = strtoupper(substr($fname, 0, 1) . substr($lname, 0, 1));
+            
+            $selfCompleted = ($a->status === 'completed' || $a->status === 'overdue');
+            $managerCompleted = ($a->review_status === 'reviewed');
+            
+            $statusLabel = 'Not Started';
+            if ($managerCompleted) {
+                $statusLabel = 'Completed';
+            } elseif ($a->review_status === 'pending_review' || ($selfCompleted && !$managerCompleted)) {
+                $statusLabel = 'Pending Manager';
+            } elseif ($a->status === 'in_progress') {
+                $statusLabel = 'In Progress';
+            } elseif ($a->status === 'overdue') {
+                $statusLabel = 'Overdue';
+            }
+
+            return [
+                'id' => (string)$a->user_id,
+                'assessment_id' => (string)$a->assessment_id,
+                'name' => trim($fname . ' ' . $lname),
+                'initials' => $initials,
+                'emp_id' => $a->employee_no ?: '',
+                'role' => $a->jobrole ?: 'N/A',
+                'self' => $selfCompleted,
+                'manager' => $managerCompleted,
+                'status' => $statusLabel,
+                'self_date' => $a->completed_at ? date('d M', strtotime($a->completed_at)) : null,
+                'manager_date' => null
+            ];
+        });
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Participants fetched successfully',
+            'data' => $data
+        ]);
+    }
+
+    /* ================================================================== *
+     * View Configuration (editable assessment settings)
+     * ================================================================== */
+
+    /**
+     * GET /competency/assessment-cycles/configuration
+     *
+     * The workspace's "View Configuration" panel: the editable settings above,
+     * plus the read-only context they operate in (the tenant rating scale, the
+     * workflow stages this module actually implements, and current counts).
+     */
+    public function configuration(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        // Rating scale: the tenant's global proficiency scale (skill_id NULL),
+        // the same scale the rating screens use.
+        $scale = DB::table('s_proficiency_levels')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('skill_id')
+            ->whereNull('deleted_at')
+            ->orderByRaw('CAST(proficiency_type AS UNSIGNED)')
+            ->get()
+            ->map(fn ($level) => [
+                'level' => (int) $level->proficiency_type,
+                'label' => $level->proficiency_level,
+                'name'  => $level->type_description,
+            ])
+            ->values()
+            ->all();
+
+        $cycleCounts = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->select('status', DB::raw('COUNT(*) as total'))
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Assessment configuration fetched successfully',
+            'data'    => [
+                'settings' => $this->competencySettings($sid, 'assessment', self::ASSESSMENT_DEFAULTS),
+                'options'  => [
+                    'approval_chain' => [
+                        ['value' => 'manager', 'label' => 'Reporting manager only'],
+                        ['value' => 'hr',      'label' => 'HR only'],
+                        ['value' => 'both',    'label' => 'Manager, then HR'],
+                    ],
+                ],
+                'context'  => [
+                    'rating_scale'      => $scale,
+                    'rating_scale_size' => count($scale),
+                    // The states reviewAssessment() and the tabs actually use.
+                    'workflow'          => ['Open', 'In Progress', 'Completed', 'Pending Review', 'Reviewed'],
+                    'frameworks'        => DB::table('s_competency_frameworks')
+                        ->where('sub_institute_id', $sid)->whereNull('deleted_at')->count(),
+                    'active_campaigns'  => (int) ($cycleCounts['active'] ?? 0),
+                    'closed_campaigns'  => (int) ($cycleCounts['closed'] ?? 0),
+                    'total_assessments' => DB::table('s_competency_assessments')
+                        ->where('sub_institute_id', $sid)->whereNull('deleted_at')->count(),
+                ],
+            ],
+        ]);
+    }
+
+    /** PUT /competency/assessment-cycles/configuration */
+    public function saveConfiguration(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'self_assessment_required' => 'sometimes|boolean',
+            'manager_review_required'  => 'sometimes|boolean',
+            'calibration_required'     => 'sometimes|boolean',
+            'approval_chain'           => 'sometimes|required|in:' . implode(',', self::APPROVAL_CHAINS),
+            'default_duration_days'    => 'sometimes|required|integer|min:1|max:365',
+            'reminder_days_before'     => 'sometimes|required|integer|min:0|max:90',
+            'allow_rating_override'    => 'sometimes|boolean',
+            'publish_results'          => 'sometimes|boolean',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $before = $this->competencySettings($sid, 'assessment', self::ASSESSMENT_DEFAULTS);
+
+        $settings = $this->saveCompetencySettings(
+            $sid,
+            'assessment',
+            $request->all(),
+            self::ASSESSMENT_DEFAULTS,
+            $context['user_id']
+        );
+
+        $labels = [
+            'self_assessment_required' => 'Self-assessment Required',
+            'manager_review_required'  => 'Manager Review Required',
+            'calibration_required'     => 'Calibration Required',
+            'approval_chain'           => 'Approval Chain',
+            'default_duration_days'    => 'Default Campaign Duration',
+            'reminder_days_before'     => 'Reminder Lead Time',
+            'allow_rating_override'    => 'Allow Rating Override',
+            'publish_results'          => 'Publish Results To Employee',
+        ];
+
+        $changes = [];
+        foreach ($labels as $key => $label) {
+            $old = is_bool($before[$key]) ? ($before[$key] ? 'Yes' : 'No') : $before[$key];
+            $new = is_bool($settings[$key]) ? ($settings[$key] ? 'Yes' : 'No') : $settings[$key];
+            if ((string) $old !== (string) $new) {
+                $changes[] = ['field' => $key, 'label' => $label, 'old' => $old, 'new' => $new];
+            }
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_assessment_config',
+            'Updated the assessment workspace configuration',
+            'assessment_cycle',
+            null,
+            'Assessment Configuration',
+            $changes
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Assessment configuration saved successfully',
+            'data'    => ['settings' => $settings],
+        ]);
+    }
+
+    /* ================================================================== *
+     * One campaign: Overview / Edit / Ratings / Calibration / Audit Trail
+     * ================================================================== */
+
+    /**
+     * GET /competency/assessment-cycles/{id}
+     *
+     * The campaign detail panel's Overview tab: the cycle itself plus the
+     * progress, completion and score roll-ups computed from its assessments.
+     */
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $cycle = $this->findCycle($id, $sid);
+        if (!$cycle) {
+            return response()->json(['status' => 0, 'message' => 'Campaign not found'], 404);
+        }
+
+        $assessments = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $sid)
+            ->where('cycle_id', $id)
+            ->whereNull('deleted_at')
+            ->get(['id', 'user_id', 'status', 'review_status', 'score', 'department_id', 'jobrole', 'completed_at']);
+
+        $total = $assessments->count();
+        $completed = $assessments->where('status', 'completed')->count();
+        $inProgress = $assessments->where('status', 'in_progress')->count();
+        $overdue = $assessments->where('status', 'overdue')->count();
+        $notStarted = $assessments->where('status', 'open')->count();
+        $reviewed = $assessments->where('review_status', 'reviewed')->count();
+        $pendingCalibration = $assessments->where('review_status', 'pending_review')->count();
+
+        $scores = $assessments->pluck('score')->filter(fn ($s) => $s !== null && $s !== '')->map(fn ($s) => (float) $s);
+
+        // Score spread, so Overview shows the distribution not just an average.
+        // NOTE s_competency_assessments.score is decimal(5,2) holding a
+        // PERCENTAGE (0-100), not a point on the 1-6 proficiency scale - so the
+        // bands are percentage bands.
+        $buckets = ['<60' => 0, '60-70' => 0, '70-80' => 0, '80-90' => 0, '90-100' => 0];
+        foreach ($scores as $score) {
+            if ($score < 60) $buckets['<60']++;
+            elseif ($score < 70) $buckets['60-70']++;
+            elseif ($score < 80) $buckets['70-80']++;
+            elseif ($score < 90) $buckets['80-90']++;
+            else $buckets['90-100']++;
+        }
+
+        // Department split - the cycle's reach across the organisation.
+        $departmentNames = DB::table('hrms_departments')
+            ->whereIn('id', $assessments->pluck('department_id')->filter()->unique()->all())
+            ->pluck('department', 'id');
+
+        $departments = $assessments
+            ->groupBy('department_id')
+            ->map(fn ($rows, $deptId) => [
+                'department' => $departmentNames[$deptId] ?? 'Unassigned',
+                'total'      => $rows->count(),
+                'completed'  => $rows->where('status', 'completed')->count(),
+            ])
+            ->sortByDesc('total')
+            ->values()
+            ->take(8)
+            ->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Campaign fetched successfully',
+            'data'    => [
+                'id'          => (string) $cycle->id,
+                'name'        => $cycle->name,
+                'type'        => $cycle->type ?: self::DEFAULT_CYCLE_TYPE,
+                'description' => $cycle->description,
+                'status'      => $cycle->status,
+                'start_date'  => $cycle->start_date,
+                'end_date'    => $cycle->end_date,
+                'start_label' => $cycle->start_date ? date('d M Y', strtotime($cycle->start_date)) : null,
+                'end_label'   => $cycle->end_date ? date('d M Y', strtotime($cycle->end_date)) : null,
+                'days_left'   => $cycle->end_date
+                    ? (int) floor((strtotime($cycle->end_date) - time()) / 86400)
+                    : null,
+                'progress'    => [
+                    'total'               => $total,
+                    'completed'           => $completed,
+                    'in_progress'         => $inProgress,
+                    'not_started'         => $notStarted,
+                    'overdue'             => $overdue,
+                    'reviewed'            => $reviewed,
+                    'pending_calibration' => $pendingCalibration,
+                    'completion_pct'      => $total > 0 ? (int) round($completed / $total * 100) : 0,
+                    'review_pct'          => $total > 0 ? (int) round($reviewed / $total * 100) : 0,
+                ],
+                'scores'      => [
+                    'rated'   => $scores->count(),
+                    'average' => $scores->count() ? round($scores->avg(), 2) : null,
+                    'min'     => $scores->count() ? round($scores->min(), 2) : null,
+                    'max'     => $scores->count() ? round($scores->max(), 2) : null,
+                    'buckets' => collect($buckets)->map(fn ($count, $range) => [
+                        'range' => $range,
+                        'count' => $count,
+                    ])->values()->all(),
+                ],
+                'departments' => $departments,
+            ],
+        ]);
+    }
+
+    /**
+     * PUT /competency/assessment-cycles/{id}
+     *
+     * "Edit Campaign". Only the cycle's own fields are writable - participants
+     * are assessments and are managed from the Participants tab.
+     */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $cycle = $this->findCycle($id, $sid);
+        if (!$cycle) {
+            return response()->json(['status' => 0, 'message' => 'Campaign not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'        => 'sometimes|required|string|max:191',
+            'type'        => 'sometimes|nullable|string|max:100',
+            'description' => 'sometimes|nullable|string',
+            'status'      => 'sometimes|required|in:scheduled,active,closed',
+            'start_date'  => 'sometimes|nullable|date',
+            'end_date'    => 'sometimes|nullable|date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = [];
+        foreach (['name', 'type', 'description', 'status', 'start_date', 'end_date'] as $field) {
+            if ($request->has($field)) {
+                $update[$field] = $request->input($field);
+            }
+        }
+
+        if ($update) {
+            DB::table('s_competency_assessment_cycles')->where('id', $id)->update($update + [
+                'updated_by' => $context['user_id'],
+                'updated_at' => now(),
+            ]);
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_assessment_cycle',
+            'Updated assessment campaign "' . ($update['name'] ?? $cycle->name) . '"',
+            'assessment_cycle',
+            (int) $id,
+            $update['name'] ?? $cycle->name,
+            $this->diffChanges($cycle, $update, [
+                'name'        => 'Campaign Name',
+                'type'        => 'Assessment Type',
+                'description' => 'Description',
+                'status'      => 'Status',
+                'start_date'  => 'Start Date',
+                'end_date'    => 'End Date',
+            ])
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Campaign updated successfully',
+            'data'    => ['id' => (int) $id],
+        ]);
+    }
+
+    /**
+     * GET /competency/assessment-cycles/{id}/ratings
+     *
+     * The Ratings tab: every rated participant in this campaign with their
+     * score, where it sits against the target, and its review state.
+     */
+    public function ratings(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        if (!$this->findCycle($id, $sid)) {
+            return response()->json(['status' => 0, 'message' => 'Campaign not found'], 404);
+        }
+
+        $target = (int) $this->competencySettings($sid, 'weighting', ['target_threshold' => 80])['target_threshold'];
+
+        $rows = DB::table('s_competency_assessments as a')
+            ->leftJoin('tbluser as u', 'u.id', '=', 'a.user_id')
+            ->leftJoin('s_competency_frameworks as f', 'f.id', '=', 'a.framework_id')
+            ->where('a.sub_institute_id', $sid)
+            ->where('a.cycle_id', $id)
+            ->whereNull('a.deleted_at')
+            ->orderByDesc('a.score')
+            ->get([
+                'a.id', 'a.user_id', 'a.jobrole', 'a.status', 'a.review_status', 'a.score',
+                'a.completed_at', 'u.first_name', 'u.last_name', 'u.employee_no', 'f.name as framework',
+            ]);
+
+        // s_competency_assessments.score is already a percentage (decimal(5,2),
+        // 0-100) - it is NOT a point on the 1-6 proficiency scale, so it is
+        // compared to the target directly rather than rescaled.
+        $data = $rows->map(function ($row) use ($target) {
+            $name = trim(($row->first_name ?? '') . ' ' . ($row->last_name ?? '')) ?: ('User ' . $row->user_id);
+            $score = $row->score !== null && $row->score !== '' ? (float) $row->score : null;
+            $pct = $score !== null ? (int) round($score) : null;
+
+            return [
+                'assessment_id' => (string) $row->id,
+                'user_id'       => (string) $row->user_id,
+                'name'          => $name,
+                'initials'      => strtoupper(substr($row->first_name ?: $name, 0, 1) . substr((string) $row->last_name, 0, 1)),
+                'emp_id'        => $row->employee_no ?: '',
+                'role'          => $row->jobrole ?: 'N/A',
+                'framework'     => $row->framework,
+                'score'         => $score,
+                'score_pct'     => $pct,
+                'target_pct'    => $target,
+                'meets_target'  => $pct !== null ? $pct >= $target : null,
+                'status'        => $row->status,
+                'review_status' => $row->review_status,
+                'rated_on'      => $row->completed_at ? date('d M Y', strtotime($row->completed_at)) : null,
+            ];
+        })->all();
+
+        $rated = array_values(array_filter($data, fn ($r) => $r['score'] !== null));
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Campaign ratings fetched successfully',
+            'data'    => $data,
+            'meta'    => [
+                'rated'         => count($rated),
+                'unrated'       => count($data) - count($rated),
+                'target_pct'    => $target,
+                'meeting'       => count(array_filter($rated, fn ($r) => $r['meets_target'] === true)),
+                'below_target'  => count(array_filter($rated, fn ($r) => $r['meets_target'] === false)),
+                'average_score' => $rated ? round(array_sum(array_column($rated, 'score')) / count($rated), 2) : null,
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/assessment-cycles/{id}/calibration-queue
+     *
+     * The Calibration tab, scoped to this campaign. Same definition the
+     * workspace-wide Calibration tab uses: completed and awaiting review.
+     */
+    public function calibrationQueue(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        if (!$this->findCycle($id, $sid)) {
+            return response()->json(['status' => 0, 'message' => 'Campaign not found'], 404);
+        }
+
+        $rows = DB::table('s_competency_assessments as a')
+            ->leftJoin('tbluser as u', 'u.id', '=', 'a.user_id')
+            ->leftJoin('hrms_departments as d', 'd.id', '=', 'a.department_id')
+            ->where('a.sub_institute_id', $sid)
+            ->where('a.cycle_id', $id)
+            ->whereNull('a.deleted_at')
+            ->where('a.status', 'completed')
+            ->where('a.review_status', 'pending_review')
+            ->orderByDesc('a.score')
+            ->get([
+                'a.id', 'a.user_id', 'a.jobrole', 'a.score', 'a.completed_at',
+                'u.first_name', 'u.last_name', 'u.employee_no', 'd.department',
+            ]);
+
+        $data = $rows->map(function ($row) {
+            $name = trim(($row->first_name ?? '') . ' ' . ($row->last_name ?? '')) ?: ('User ' . $row->user_id);
+
+            return [
+                'assessment_id' => (string) $row->id,
+                'user_id'       => (string) $row->user_id,
+                'name'          => $name,
+                'initials'      => strtoupper(substr($row->first_name ?: $name, 0, 1) . substr((string) $row->last_name, 0, 1)),
+                'emp_id'        => $row->employee_no ?: '',
+                'role'          => $row->jobrole ?: 'N/A',
+                'department'    => $row->department,
+                'score'         => $row->score !== null && $row->score !== '' ? (float) $row->score : null,
+                'completed_on'  => $row->completed_at ? date('d M Y', strtotime($row->completed_at)) : null,
+            ];
+        })->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Calibration queue fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * GET /competency/assessment-cycles/{id}/audit-trail
+     *
+     * The Audit Trail tab: this campaign's slice of the shared competency
+     * activity feed - entries against the cycle itself and against every
+     * assessment inside it.
+     */
+    public function auditTrail(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $cycle = $this->findCycle($id, $sid);
+        if (!$cycle) {
+            return response()->json(['status' => 0, 'message' => 'Campaign not found'], 404);
+        }
+
+        $assessmentIds = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $sid)
+            ->where('cycle_id', $id)
+            ->pluck('id')
+            ->all();
+
+        $entries = DB::table('s_competency_activity_log')
+            ->where('sub_institute_id', $sid)
+            ->where(function ($q) use ($id, $assessmentIds) {
+                $q->where(function ($q2) use ($id) {
+                    $q2->where('subject_type', 'assessment_cycle')->where('subject_id', $id);
+                });
+                if ($assessmentIds) {
+                    $q->orWhere(function ($q2) use ($assessmentIds) {
+                        $q2->where('subject_type', 'assessment')->whereIn('subject_id', $assessmentIds);
+                    });
+                }
+            })
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->limit(200)
+            ->get();
+
+        $data = $entries->map(fn ($e) => [
+            'id'          => (int) $e->id,
+            'action'      => $e->action,
+            'description' => $e->description,
+            'record'      => $e->subject_name,
+            'by'          => $e->actor_name ?: 'System',
+            'at'          => $e->created_at,
+            'date'        => $e->created_at ? date('d M Y, h:i A', strtotime($e->created_at)) : null,
+            'changes'     => $e->changes ? (json_decode($e->changes, true) ?: []) : [],
+        ])->all();
+
+        // The cycle's own audit stamps, so a campaign that predates the feed
+        // still shows something meaningful.
+        $stamps = [];
+        if ($cycle->created_at) {
+            $stamps[] = ['label' => 'Campaign created', 'date' => date('d M Y', strtotime($cycle->created_at))];
+        }
+        if ($cycle->updated_at && $cycle->updated_at !== $cycle->created_at) {
+            $stamps[] = ['label' => 'Last updated', 'date' => date('d M Y', strtotime($cycle->updated_at))];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Campaign audit trail fetched successfully',
+            'data'    => $data,
+            'meta'    => ['stamps' => $stamps, 'assessments' => count($assessmentIds)],
+        ]);
+    }
+
+    /** Tenant-scoped cycle lookup shared by the campaign endpoints. */
+    private function findCycle($id, int $sid)
+    {
+        return DB::table('s_competency_assessment_cycles')
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+    }
+}

--- a/app/Http/Controllers/Api/Competency/AuditController.php
+++ b/app/Http/Controllers/Api/Competency/AuditController.php
@@ -1,0 +1,969 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Audit & Activity Center (competency module, submenu cm-audit).
+ *
+ * The whole screen reads one table - s_competency_activity_log - which every
+ * competency controller already writes to through
+ * ResolvesCompetencyContext::logCompetencyActivity(). Nothing here writes to a
+ * domain table; the only write is the export event this controller logs about
+ * itself.
+ *
+ * Two things the raw table does not store are derived here rather than
+ * duplicated into columns:
+ *
+ *  - "Module"      -> MODULES, keyed off subject_type. A record type belongs to
+ *                     exactly one competency screen, so a map is the truth and a
+ *                     column would only be able to drift from it.
+ *  - "Action"      -> normaliseAction(), which turns the stored snake_case verb
+ *                     (created_framework, bulk_verify_certifications, ...) into
+ *                     the display verb the table shows plus the class the tabs
+ *                     and KPI cards group by.
+ *
+ * The "User Actions Log" tab is the one place that reaches outside this table:
+ * its per-user rollup comes from the activity log, and drilling into a user also
+ * shows that user's screen-access history from tbl_user_journey_logs (the
+ * existing page-visit clickstream, joined to tblmenumaster for screen names).
+ *
+ * Conventions match the rest of Api/Competency: Sanctum token in `token`,
+ * tenant in `sub_institute_id`, {status, message, data[, pagination]} envelope.
+ * NOTE `user_id` is the CONTEXT ACTOR on every /competency/* call - the user
+ * being filtered on travels as `user_id_filter`.
+ */
+class AuditController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    private const TABLE = 's_competency_activity_log';
+
+    /** Hard ceiling on an export so a runaway request stays bounded. */
+    private const EXPORT_LIMIT = 5000;
+
+    /**
+     * subject_type => [record type label, module key, module label, submenu id].
+     * The submenu id is what the detail panel's "Record Link" opens - the
+     * frontend turns it into /module/m2/{submenu}/{submenu}.
+     */
+    private const SUBJECTS = [
+        'competency'                => ['Competency',               'library',       'Competency Library',        'cm-competency-library'],
+        'framework'                 => ['Framework',                'framework',     'Framework & Role Mapping',  'cm-framework-mapping'],
+        'framework_item'            => ['Framework Item',           'framework',     'Framework & Role Mapping',  'cm-framework-mapping'],
+        'framework_weight'          => ['Framework Weighting',      'framework',     'Framework & Role Mapping',  'cm-framework-mapping'],
+        'proficiency_level'         => ['Proficiency Level',        'framework',     'Framework & Role Mapping',  'cm-framework-mapping'],
+        'role_mapping'              => ['Role Mapping',             'role_mapping',  'Role Mapping',              'cm-framework-mapping'],
+        'mapping_review'            => ['Mapping Review',           'role_mapping',  'Role Mapping',              'cm-framework-mapping'],
+        'assessment'                => ['Assessment',               'assessments',   'Assessments',               'cm-assessment-workspace'],
+        'assessment_cycle'          => ['Assessment Cycle',         'assessments',   'Assessments',               'cm-assessment-workspace'],
+        'certification'             => ['Certification',            'certifications','Certifications',            'cm-certifications'],
+        'certification_requirement' => ['Certification Requirement','certifications','Certifications',            'cm-certifications'],
+        // Every 'development' row must carry the SAME module label - filters()
+        // groups by module key and keeps the first label it meets, so a
+        // mismatch here would surface as a label that changes with the data.
+        'development_plan'          => ['Development Plan',         'development',   'Development & Career',      'cm-development-career'],
+        'plan_action'               => ['Plan Action',              'development',   'Development & Career',      'cm-development-career'],
+        'career_path'               => ['Career Path',              'development',   'Development & Career',      'cm-development-career'],
+        'learning_assignment'       => ['Learning Assignment',      'development',   'Development & Career',      'cm-development-career'],
+        'evidence'                  => ['Evidence',                 'profiles',      'Employee Profile',          'cm-employee-profiles'],
+        'employee_note'             => ['Employee Note',            'profiles',      'Employee Profile',          'cm-employee-profiles'],
+        'employee_skill'            => ['Employee Competency',      'profiles',      'Employee Profile',          'cm-employee-profiles'],
+        'audit_log'                 => ['Audit Log',                'administration','Administration',            'cm-audit'],
+    ];
+
+    /**
+     * Stored action verb => [display label, class]. Matched longest-prefix
+     * first, so 'bulk_verify_certifications' resolves through 'bulk_verify'
+     * before the bare 'verify' entry is ever consulted.
+     *
+     * Classes drive both the tabs and the KPI cards:
+     *   create | update | delete | approval | comment | io | assignment | mapping
+     */
+    private const ACTIONS = [
+        'bulk_delete'  => ['Deleted',   'delete'],
+        'bulk_verify'  => ['Verified',  'approval'],
+        'bulk_reject'  => ['Rejected',  'approval'],
+        'bulk_revoke'  => ['Revoked',   'update'],
+        'bulk_status'  => ['Updated',   'update'],
+        'bulk_'        => ['Updated',   'update'],
+        'imported'     => ['Imported',  'io'],
+        'import'       => ['Imported',  'io'],
+        'exported'     => ['Exported',  'io'],
+        'export'       => ['Exported',  'io'],
+        'uploaded'     => ['Uploaded',  'io'],
+        'attached'     => ['Uploaded',  'io'],
+        'added_certification_document' => ['Uploaded', 'io'],
+        'commented'    => ['Commented', 'comment'],
+        'comment'      => ['Commented', 'comment'],
+        'noted'        => ['Commented', 'comment'],
+        'saved_note'   => ['Commented', 'comment'],
+        'approved'     => ['Approved',  'approval'],
+        'approve'      => ['Approved',  'approval'],
+        'rejected'     => ['Rejected',  'approval'],
+        'reject'       => ['Rejected',  'approval'],
+        'calibrated'   => ['Calibrated','approval'],
+        'calibrate'    => ['Calibrated','approval'],
+        'verified'     => ['Verified',  'approval'],
+        'published'    => ['Published', 'approval'],
+        'submitted'    => ['Submitted', 'approval'],
+        'certified'    => ['Certified', 'approval'],
+        'completed'    => ['Completed', 'update'],
+        'assigned'     => ['Assigned',  'assignment'],
+        'unassigned'   => ['Unassigned','assignment'],
+        'mapped'       => ['Mapped',    'mapping'],
+        'unmapped'     => ['Unmapped',  'mapping'],
+        'created'      => ['Created',   'create'],
+        'added'        => ['Created',   'create'],
+        'launched'     => ['Created',   'create'],
+        'cloned'       => ['Cloned',    'create'],
+        'updated'      => ['Updated',   'update'],
+        'changed'      => ['Updated',   'update'],
+        'set'          => ['Updated',   'update'],
+        'saved'        => ['Updated',   'update'],
+        'deleted'      => ['Deleted',   'delete'],
+        'removed'      => ['Deleted',   'delete'],
+    ];
+
+    /** Tab id => the action classes it shows. 'history' and 'actions' are special. */
+    private const TABS = [
+        'approvals' => ['approval'],
+        'comments'  => ['comment'],
+        'io'        => ['io'],
+    ];
+
+    /* ================================================================== *
+     * List
+     * ================================================================== */
+
+    /**
+     * GET /competency/audit
+     *
+     * The main table. `tab` selects the slice (timeline = everything,
+     * history = only entries carrying a field-level diff), the rest are the
+     * filter bar's controls.
+     */
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 25), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = $this->filteredQuery($request, $sid);
+        $total = (clone $query)->count();
+
+        [$column, $direction] = $this->sortFor($request);
+
+        $rows = $query->orderBy($column, $direction)
+            ->orderByDesc('id')
+            ->forPage($page, $perPage)
+            ->get();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Activities fetched successfully',
+            'data'       => $this->decorate($rows),
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/audit/metrics
+     *
+     * The five KPI cards. They honour the active filters (so the numbers always
+     * describe what the table below is showing) and report the range they cover
+     * back to the card sub-label, which is why `range_label` travels with them.
+     */
+    public function metrics(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        // Metrics describe the filtered set, not one tab of it.
+        $rows = $this->filteredQuery($request, $sid, false)
+            ->get(['action', 'changes']);
+
+        $counts = ['total' => $rows->count(), 'approvals' => 0, 'updates' => 0, 'comments' => 0, 'io' => 0, 'versions' => 0];
+
+        foreach ($rows as $row) {
+            [, $class] = $this->normaliseAction($row->action);
+
+            if ($class === 'approval') {
+                $counts['approvals']++;
+            } elseif ($class === 'update') {
+                $counts['updates']++;
+            } elseif ($class === 'comment') {
+                $counts['comments']++;
+            } elseif ($class === 'io') {
+                $counts['io']++;
+            }
+
+            if (!empty($row->changes) && $row->changes !== 'null' && $row->changes !== '[]') {
+                $counts['versions']++;
+            }
+        }
+
+        $from = $this->dateInput($request, 'from');
+        $to = $this->dateInput($request, 'to');
+
+        if ($from && $to) {
+            $label = date('d M Y', strtotime($from)) . ' - ' . date('d M Y', strtotime($to));
+        } elseif ($from) {
+            $label = 'Since ' . date('d M Y', strtotime($from));
+        } elseif ($to) {
+            $label = 'Up to ' . date('d M Y', strtotime($to));
+        } else {
+            $label = 'All time';
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Audit metrics fetched successfully',
+            'data'    => [
+                'total'            => $counts['total'],
+                'approvals'        => $counts['approvals'],
+                'updates'          => $counts['updates'],
+                'comments'         => $counts['comments'],
+                'imports_exports'  => $counts['io'],
+                'version_entries'  => $counts['versions'],
+                'range_label'      => $label,
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/audit/filters
+     *
+     * Options for the four selects in the filter bar. Record types and modules
+     * are built from what the tenant's log actually contains, so a dimension
+     * with nothing behind it never shows up as a dead option.
+     */
+    public function filters(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $types = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNotNull('subject_type')
+            ->select('subject_type', DB::raw('COUNT(*) as total'))
+            ->groupBy('subject_type')
+            ->get();
+
+        $recordTypes = [];
+        $modules = [];
+
+        foreach ($types as $type) {
+            [$typeLabel, $moduleKey, $moduleLabel] = $this->subjectMeta($type->subject_type);
+
+            $recordTypes[] = [
+                'value' => $type->subject_type,
+                'label' => $typeLabel,
+                'count' => (int) $type->total,
+            ];
+
+            if (!isset($modules[$moduleKey])) {
+                $modules[$moduleKey] = ['value' => $moduleKey, 'label' => $moduleLabel, 'count' => 0];
+            }
+            $modules[$moduleKey]['count'] += (int) $type->total;
+        }
+
+        usort($recordTypes, fn ($a, $b) => strcmp($a['label'], $b['label']));
+        $modules = array_values($modules);
+        usort($modules, fn ($a, $b) => strcmp($a['label'], $b['label']));
+
+        $users = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNotNull('user_id')
+            ->select('user_id', DB::raw('MAX(actor_name) as actor_name'), DB::raw('COUNT(*) as total'))
+            ->groupBy('user_id')
+            ->orderByDesc('total')
+            ->get()
+            ->map(fn ($u) => [
+                'value' => (string) $u->user_id,
+                'label' => $u->actor_name ?: ('User ' . $u->user_id),
+                'count' => (int) $u->total,
+            ])
+            ->all();
+
+        // The date-range select: presets the filter bar offers out of the box.
+        $ranges = [
+            ['value' => 'all',   'label' => 'All time'],
+            ['value' => '7d',    'label' => 'Last 7 days'],
+            ['value' => '30d',   'label' => 'Last 30 days'],
+            ['value' => '90d',   'label' => 'Last 90 days'],
+            ['value' => 'month', 'label' => 'This month'],
+            ['value' => 'year',  'label' => 'This year'],
+        ];
+
+        $actions = [];
+        foreach (self::ACTIONS as $meta) {
+            $actions[$meta[1]] = ['value' => $meta[1], 'label' => $this->classLabel($meta[1])];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Audit filters fetched successfully',
+            'data'    => [
+                'record_types'   => $recordTypes,
+                'modules'        => $modules,
+                'users'          => $users,
+                'date_ranges'    => $ranges,
+                'action_classes' => array_values($actions),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/audit/export
+     *
+     * Every row matching the current filters (capped), for the header's Export
+     * button; the CSV is assembled client side so no new dependency is needed.
+     * The export is itself logged, which is why it turns up in the
+     * Imports / Exports tab straight after it runs.
+     */
+    public function export(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $rows = $this->filteredQuery($request, $sid)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->limit(self::EXPORT_LIMIT)
+            ->get();
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'exported_audit_log',
+            'Exported ' . $rows->count() . ' audit ' . ($rows->count() === 1 ? 'entry' : 'entries'),
+            'audit_log',
+            null,
+            'Audit & Activity Log'
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Activities exported successfully',
+            'data'    => $this->decorate($rows),
+        ]);
+    }
+
+    /* ================================================================== *
+     * Detail panel
+     * ================================================================== */
+
+    /**
+     * GET /competency/audit/{id}
+     *
+     * The right-hand panel: Overview, Change Summary (only populated when the
+     * originating endpoint recorded a diff) and the resolved Record Link.
+     */
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->where('id', $id)
+            ->first();
+
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Activity not found'], 404);
+        }
+
+        $entry = $this->decorateRow($row);
+
+        // Sibling entries against the same record, so the panel can show what
+        // else happened to it without a second round trip.
+        $related = [];
+        if ($row->subject_type && $row->subject_id) {
+            $related = DB::table(self::TABLE)
+                ->where('sub_institute_id', $sid)
+                ->where('subject_type', $row->subject_type)
+                ->where('subject_id', $row->subject_id)
+                ->where('id', '!=', $row->id)
+                ->orderByDesc('created_at')
+                ->orderByDesc('id')
+                ->limit(10)
+                ->get();
+            $related = $this->decorate($related);
+        }
+
+        $entry['related'] = $related;
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Activity fetched successfully',
+            'data'    => $entry,
+        ]);
+    }
+
+    /* ================================================================== *
+     * User Actions Log tab
+     * ================================================================== */
+
+    /**
+     * GET /competency/audit/user-actions
+     *
+     * Per-actor rollup of the same feed: how much each user did, split by action
+     * class, and when they were last active. Honours the filter bar's date range
+     * and search box so the tab stays in step with the rest of the screen.
+     */
+    public function userActions(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $rows = $this->filteredQuery($request, $sid, false)
+            ->get(['user_id', 'actor_name', 'action', 'created_at']);
+
+        $users = [];
+
+        foreach ($rows as $row) {
+            $key = $row->user_id ? (string) $row->user_id : 'system';
+
+            if (!isset($users[$key])) {
+                $users[$key] = [
+                    'user_id'   => $row->user_id ? (int) $row->user_id : null,
+                    'user'      => $row->actor_name ?: 'System',
+                    'initials'  => $this->initials($row->actor_name ?: 'System'),
+                    'total'     => 0,
+                    'created'   => 0,
+                    'updated'   => 0,
+                    'deleted'   => 0,
+                    'approved'  => 0,
+                    'commented' => 0,
+                    'other'     => 0,
+                    'last_at'   => null,
+                ];
+            }
+
+            [, $class] = $this->normaliseAction($row->action);
+
+            $users[$key]['total']++;
+            $bucket = [
+                'create'   => 'created',
+                'update'   => 'updated',
+                'delete'   => 'deleted',
+                'approval' => 'approved',
+                'comment'  => 'commented',
+            ][$class] ?? 'other';
+            $users[$key][$bucket]++;
+
+            if ($row->created_at && (!$users[$key]['last_at'] || $row->created_at > $users[$key]['last_at'])) {
+                $users[$key]['last_at'] = $row->created_at;
+            }
+        }
+
+        $users = array_values($users);
+        usort($users, fn ($a, $b) => $b['total'] <=> $a['total']);
+
+        foreach ($users as &$user) {
+            $user['last_active'] = $this->timestampLabel($user['last_at']);
+        }
+        unset($user);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'User actions fetched successfully',
+            'data'    => $users,
+        ]);
+    }
+
+    /**
+     * GET /competency/audit/user-actions/{userId}
+     *
+     * Drill-down for one actor: their record changes from the competency feed,
+     * plus their screen-access history from tbl_user_journey_logs - the existing
+     * page-visit clickstream, joined to tblmenumaster for the screen name. The
+     * access log is a different kind of evidence from the rest of the page, so
+     * it is returned as its own list rather than merged into the timeline.
+     */
+    public function userActivity(Request $request, $userId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $changes = $this->filteredQuery($request, $sid, false)
+            ->where('user_id', $userId)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->limit(50)
+            ->get();
+
+        $access = DB::table('tbl_user_journey_logs as j')
+            ->leftJoin('tblmenumaster as m', 'm.id', '=', 'j.menu_id')
+            ->where('j.sub_institute_id', $sid)
+            ->where('j.user_id', $userId)
+            ->orderByDesc('j.timestamp')
+            ->orderByDesc('j.id')
+            ->limit(50)
+            ->get([
+                'j.id',
+                'j.event_type',
+                'j.access_link',
+                'j.step_key',
+                'j.timestamp',
+                'm.menu_name',
+            ])
+            ->map(fn ($a) => [
+                'id'         => (int) $a->id,
+                'screen'     => $a->menu_name ?: 'Unknown screen',
+                'event'      => $this->eventLabel($a->event_type),
+                'event_type' => $a->event_type,
+                'link'       => $this->cleanAccessLink($a->access_link),
+                'step_key'   => $a->step_key,
+                'at'         => $a->timestamp,
+                'date'       => $this->timestampLabel($a->timestamp),
+            ])
+            ->all();
+
+        $user = DB::table('tbluser')->where('id', $userId)->first();
+        $name = $user
+            ? (trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? '')) ?: ($user->user_name ?? 'User ' . $userId))
+            : ('User ' . $userId);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'User activity fetched successfully',
+            'data'    => [
+                'user' => [
+                    'id'       => (int) $userId,
+                    'name'     => $name,
+                    'initials' => $this->initials($name),
+                ],
+                'changes'    => $this->decorate($changes),
+                'access_log' => $access,
+            ],
+        ]);
+    }
+
+    /* ================================================================== *
+     * Query building
+     * ================================================================== */
+
+    /**
+     * The shared filter chain. $applyTab is false for the KPI cards and the
+     * user rollup, which describe the filtered set as a whole rather than one
+     * tab of it.
+     */
+    private function filteredQuery(Request $request, int $sid, bool $applyTab = true)
+    {
+        $query = DB::table(self::TABLE)->where('sub_institute_id', $sid);
+
+        if ($applyTab) {
+            $this->applyTab($query, (string) $request->input('tab', 'timeline'));
+        }
+
+        if ($from = $this->dateInput($request, 'from')) {
+            $query->where('created_at', '>=', $from . ' 00:00:00');
+        }
+
+        if ($to = $this->dateInput($request, 'to')) {
+            $query->where('created_at', '<=', $to . ' 23:59:59');
+        }
+
+        if ($recordType = $this->activeFilter($request->input('record_type'))) {
+            $query->whereIn('subject_type', array_map('trim', explode(',', $recordType)));
+        }
+
+        if ($module = $this->activeFilter($request->input('module'))) {
+            $types = [];
+            foreach (self::SUBJECTS as $subject => $meta) {
+                if ($meta[1] === $module) {
+                    $types[] = $subject;
+                }
+            }
+            // An unknown module key must not silently widen the result set.
+            $query->whereIn('subject_type', $types ?: ['__none__']);
+        }
+
+        // NOTE: `user_id` is the calling actor on every /competency/* route, so
+        // the user being filtered on has to travel under its own name.
+        if ($actor = $this->activeFilter($request->input('user_id_filter'))) {
+            $query->where('user_id', (int) $actor);
+        }
+
+        if ($class = $this->activeFilter($request->input('action_class'))) {
+            $this->applyActionClasses($query, array_map('trim', explode(',', $class)));
+        }
+
+        if ($search = trim((string) $request->input('search', ''))) {
+            $like = '%' . $search . '%';
+            $query->where(function ($q) use ($like) {
+                $q->where('subject_name', 'like', $like)
+                    ->orWhere('description', 'like', $like)
+                    ->orWhere('actor_name', 'like', $like)
+                    ->orWhere('action', 'like', $like);
+            });
+        }
+
+        return $query;
+    }
+
+    /**
+     * Tab -> slice of the feed. `history` is the only tab that is not an action
+     * class: it shows the entries that actually carry a field-level diff, which
+     * is exactly what a version history is.
+     */
+    private function applyTab($query, string $tab): void
+    {
+        if ($tab === 'history') {
+            $query->whereNotNull('changes')
+                ->where('changes', '!=', '')
+                ->where('changes', '!=', '[]')
+                ->where('changes', '!=', 'null');
+            return;
+        }
+
+        if (isset(self::TABS[$tab])) {
+            $this->applyActionClasses($query, self::TABS[$tab]);
+        }
+
+        // 'timeline' and 'actions' both read the whole feed.
+    }
+
+    /**
+     * Action classes are derived, not stored, so filtering by one means matching
+     * every stored verb that maps to it. Cheap here because the map is small and
+     * the resulting LIKE set is bounded by the prefix list.
+     *
+     * @param array<int, string> $classes
+     */
+    private function applyActionClasses($query, array $classes): void
+    {
+        $prefixes = [];
+        foreach (self::ACTIONS as $prefix => $meta) {
+            if (in_array($meta[1], $classes, true)) {
+                $prefixes[] = $prefix;
+            }
+        }
+
+        if (!$prefixes) {
+            $query->whereRaw('1 = 0');
+            return;
+        }
+
+        $query->where(function ($q) use ($prefixes) {
+            foreach ($prefixes as $prefix) {
+                // Stored verbs are either the prefix itself ('approved') or the
+                // prefix followed by the subject ('approved_mapping_review').
+                $q->orWhere('action', $prefix)
+                    ->orWhere('action', 'like', $prefix . '%');
+            }
+        });
+    }
+
+    /** @return array{0:string, 1:string} [column, direction] */
+    private function sortFor(Request $request): array
+    {
+        $map = [
+            'date'   => 'created_at',
+            'user'   => 'actor_name',
+            'action' => 'action',
+            'record' => 'subject_name',
+            'type'   => 'subject_type',
+        ];
+
+        $column = $map[(string) $request->input('sort', 'date')] ?? 'created_at';
+        $direction = strtolower((string) $request->input('direction', 'desc')) === 'asc' ? 'asc' : 'desc';
+
+        return [$column, $direction];
+    }
+
+    /**
+     * Accepts either an explicit from/to date or the `range` preset the filter
+     * bar's first select offers.
+     */
+    private function dateInput(Request $request, string $key): ?string
+    {
+        $explicit = $this->activeFilter($request->input($key));
+        if ($explicit) {
+            $stamp = strtotime($explicit);
+            return $stamp ? date('Y-m-d', $stamp) : null;
+        }
+
+        $range = $this->activeFilter($request->input('range'));
+        if (!$range) {
+            return null;
+        }
+
+        $bounds = [
+            '7d'    => [date('Y-m-d', strtotime('-7 days')), date('Y-m-d')],
+            '30d'   => [date('Y-m-d', strtotime('-30 days')), date('Y-m-d')],
+            '90d'   => [date('Y-m-d', strtotime('-90 days')), date('Y-m-d')],
+            'month' => [date('Y-m-01'), date('Y-m-t')],
+            'year'  => [date('Y-01-01'), date('Y-12-31')],
+        ];
+
+        if (!isset($bounds[$range])) {
+            return null;
+        }
+
+        return $key === 'from' ? $bounds[$range][0] : $bounds[$range][1];
+    }
+
+    /* ================================================================== *
+     * Decoration
+     * ================================================================== */
+
+    /** @param \Illuminate\Support\Collection $rows */
+    private function decorate($rows): array
+    {
+        return collect($rows)->map(fn ($row) => $this->decorateRow($row))->values()->all();
+    }
+
+    private function decorateRow($row): array
+    {
+        [$typeLabel, $moduleKey, $moduleLabel, $submenu] = $this->subjectMeta($row->subject_type);
+        [$actionLabel, $actionClass] = $this->normaliseAction($row->action);
+
+        $changes = $this->decodeChanges($row->changes ?? null);
+        $actor = $row->actor_name ?: 'System';
+
+        // Rows written before subject_name existed still carry the record name
+        // inside the description, so fall back to what is quoted there.
+        $recordName = $row->subject_name ?: $this->nameFromDescription($row->description);
+
+        return [
+            'id'              => (int) $row->id,
+            'at'              => $row->created_at,
+            'date'            => $row->created_at ? date('d M Y, h:i A', strtotime((string) $row->created_at)) : null,
+            'relative'        => $this->timestampLabel($row->created_at),
+            'user_id'         => $row->user_id ? (int) $row->user_id : null,
+            'user'            => $actor,
+            'initials'        => $this->initials($actor),
+            'action'          => $actionLabel,
+            'action_class'    => $actionClass,
+            'action_raw'      => $row->action,
+            'record_type'     => $typeLabel,
+            'record_type_key' => $row->subject_type,
+            'record_name'     => $recordName,
+            'record_id'       => $row->subject_id ? (int) $row->subject_id : null,
+            'module'          => $moduleLabel,
+            'module_key'      => $moduleKey,
+            'submenu_id'      => $submenu,
+            'description'     => $row->description,
+            'changes'         => $changes,
+            'changes_count'   => count($changes),
+            'has_changes'     => $changes !== [],
+        ];
+    }
+
+    /** @return array<int, array{field:string, label:string, old:?string, new:?string}> */
+    private function decodeChanges($raw): array
+    {
+        if (!$raw) {
+            return [];
+        }
+
+        $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $changes = [];
+        foreach ($decoded as $change) {
+            if (!is_array($change) || !isset($change['field'])) {
+                continue;
+            }
+
+            $changes[] = [
+                'field' => (string) $change['field'],
+                'label' => (string) ($change['label'] ?? ucwords(str_replace('_', ' ', (string) $change['field']))),
+                'old'   => $this->scalarValue($change['old'] ?? null),
+                'new'   => $this->scalarValue($change['new'] ?? null),
+            ];
+        }
+
+        return $changes;
+    }
+
+    private function scalarValue($value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'Yes' : 'No';
+        }
+
+        if (is_array($value)) {
+            return implode(', ', array_map(fn ($item) => (string) $item, $value));
+        }
+
+        return (string) $value;
+    }
+
+    /** @return array{0:string, 1:string, 2:string, 3:?string} */
+    private function subjectMeta(?string $subjectType): array
+    {
+        if ($subjectType && isset(self::SUBJECTS[$subjectType])) {
+            return self::SUBJECTS[$subjectType];
+        }
+
+        if ($subjectType) {
+            return [ucwords(str_replace('_', ' ', $subjectType)), 'other', 'Competency Management', null];
+        }
+
+        return ['Competency Management', 'other', 'Competency Management', null];
+    }
+
+    /**
+     * Stored verb -> [display label, class]. Longest prefix wins, so
+     * 'bulk_verify_certifications' never falls through to the bare 'verify'
+     * rule and 'added_certification_document' is an upload, not a create.
+     *
+     * @return array{0:string, 1:string}
+     */
+    private function normaliseAction(?string $action): array
+    {
+        $action = strtolower(trim((string) $action));
+
+        if ($action === '') {
+            return ['Activity', 'other'];
+        }
+
+        $best = null;
+        $bestLength = 0;
+
+        foreach (self::ACTIONS as $prefix => $meta) {
+            if ($action === $prefix || str_starts_with($action, $prefix)) {
+                if (strlen($prefix) > $bestLength) {
+                    $best = $meta;
+                    $bestLength = strlen($prefix);
+                }
+            }
+        }
+
+        if ($best) {
+            return $best;
+        }
+
+        return [ucwords(str_replace('_', ' ', $action)), 'other'];
+    }
+
+    private function classLabel(string $class): string
+    {
+        return [
+            'create'     => 'Created',
+            'update'     => 'Updated',
+            'delete'     => 'Deleted',
+            'approval'   => 'Approvals',
+            'comment'    => 'Comments',
+            'io'         => 'Imports / Exports',
+            'assignment' => 'Assignments',
+            'mapping'    => 'Role Mappings',
+        ][$class] ?? ucfirst($class);
+    }
+
+    /** Pull the quoted record name out of a legacy description line. */
+    private function nameFromDescription(?string $description): ?string
+    {
+        if (!$description) {
+            return null;
+        }
+
+        return preg_match('/"([^"]+)"/', $description, $matches) ? $matches[1] : null;
+    }
+
+    private function initials(string $name): string
+    {
+        $parts = preg_split('/\s+/', trim($name)) ?: [];
+        $first = $parts[0] ?? '';
+        $last = count($parts) > 1 ? end($parts) : '';
+
+        $initials = strtoupper(substr($first, 0, 1) . substr((string) $last, 0, 1));
+
+        return $initials !== '' ? $initials : '?';
+    }
+
+    private function timestampLabel($value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+
+        $stamp = strtotime((string) $value);
+        if (!$stamp) {
+            return null;
+        }
+
+        $diff = time() - $stamp;
+
+        if ($diff < 60) {
+            return 'Just now';
+        }
+        if ($diff < 3600) {
+            $mins = (int) floor($diff / 60);
+            return $mins . ' min' . ($mins === 1 ? '' : 's') . ' ago';
+        }
+        if ($diff < 86400) {
+            $hours = (int) floor($diff / 3600);
+            return $hours . ' hour' . ($hours === 1 ? '' : 's') . ' ago';
+        }
+        if ($diff < 604800) {
+            $days = (int) floor($diff / 86400);
+            return $days . ' day' . ($days === 1 ? '' : 's') . ' ago';
+        }
+
+        return date('d M Y', $stamp);
+    }
+
+    private function eventLabel(?string $eventType): string
+    {
+        return [
+            'page_visit'         => 'Opened screen',
+            'tour_step_view'     => 'Viewed tour step',
+            'tour_step_complete' => 'Completed tour step',
+            'tour_skipped'       => 'Skipped tour',
+        ][$eventType] ?? ucwords(str_replace('_', ' ', (string) $eventType));
+    }
+
+    /** The clickstream stores a placeholder string when a menu has no route. */
+    private function cleanAccessLink(?string $link): ?string
+    {
+        if (!$link || str_starts_with($link, 'No access link')) {
+            return null;
+        }
+
+        return $link;
+    }
+}

--- a/app/Http/Controllers/Api/Competency/CareerPathController.php
+++ b/app/Http/Controllers/Api/Competency/CareerPathController.php
@@ -1,0 +1,820 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Named career paths (s_competency_career_paths / _steps) for the Development &
+ * Career Path Workspace's "Career Paths" tab and "Career Path Explorer" card.
+ *
+ * Two existing sources are read, never duplicated:
+ *   - s_user_jobrole      : the role catalog a path's steps point at
+ *   - career_journey      : the tenant's role-progression edge graph, used to
+ *                           suggest the next roles when authoring a path and as
+ *                           the fallback chain when a plan has no named path
+ *                           (the same table CareerJourneyController reads and
+ *                           the old frontend's Succession screen consumed).
+ *
+ * "% Match" on an explorer node is readiness: how much of the target role's
+ * required proficiency (s_user_skill_jobrole) the employee already holds
+ * (s_skill_matrix) - the same comparison the old frontend computed from
+ * next-role KASA vs user ratings.
+ */
+class CareerPathController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    private const PATHS = 's_competency_career_paths';
+    private const STEPS = 's_competency_career_path_steps';
+
+    /* ================================================================== *
+     * Paths CRUD
+     * ================================================================== */
+
+    /** GET /competency/career-paths */
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 25), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table(self::PATHS)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('name', 'like', "%{$search}%");
+        }
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('status', $status);
+        }
+        if ($departmentId = $this->activeFilter($request->input('department_id'))) {
+            $query->where('department_id', $departmentId);
+        }
+
+        $total = (clone $query)->count();
+        $rows = $query->orderByDesc('id')->forPage($page, $perPage)->get();
+
+        $pathIds = $rows->pluck('id')->all();
+
+        $stepCounts = [];
+        $firstSteps = [];
+        if ($pathIds) {
+            $stepCounts = DB::table(self::STEPS)
+                ->whereIn('career_path_id', $pathIds)->whereNull('deleted_at')
+                ->selectRaw('career_path_id, COUNT(*) as c')
+                ->groupBy('career_path_id')->pluck('c', 'career_path_id')->all();
+
+            $firstSteps = DB::table(self::STEPS)
+                ->whereIn('career_path_id', $pathIds)->whereNull('deleted_at')
+                ->orderBy('step_order')->get(['career_path_id', 'jobrole', 'step_order'])
+                ->groupBy('career_path_id')
+                ->map(fn ($group) => $group->pluck('jobrole')->all())
+                ->all();
+        }
+
+        $planCounts = [];
+        if ($pathIds) {
+            $planCounts = DB::table('s_competency_development_plans')
+                ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+                ->whereIn('career_path_id', $pathIds)
+                ->selectRaw('career_path_id, COUNT(*) as c')
+                ->groupBy('career_path_id')->pluck('c', 'career_path_id')->all();
+        }
+
+        $data = $rows->map(fn ($r) => [
+            'id'           => (int) $r->id,
+            'name'         => $r->name,
+            'description'  => $r->description,
+            'department_id'=> $r->department_id ? (int) $r->department_id : null,
+            'department'   => $r->department,
+            'job_family'   => $r->job_family,
+            'status'       => $r->status,
+            'step_count'   => (int) ($stepCounts[$r->id] ?? 0),
+            'roles'        => $firstSteps[$r->id] ?? [],
+            'linked_plans' => (int) ($planCounts[$r->id] ?? 0),
+            'created_at'   => $r->created_at ? date('d M Y', strtotime($r->created_at)) : null,
+        ])->all();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Career paths fetched successfully',
+            'data'       => $data,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /** GET /competency/career-paths/{id} */
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $path = $this->findPath($id, $sid);
+        if (!$path) {
+            return response()->json(['status' => 0, 'message' => 'Career path not found'], 404);
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Career path fetched successfully',
+            'data'    => [
+                'id'            => (int) $path->id,
+                'name'          => $path->name,
+                'description'   => $path->description,
+                'department_id' => $path->department_id ? (int) $path->department_id : null,
+                'department'    => $path->department,
+                'job_family'    => $path->job_family,
+                'status'        => $path->status,
+                'steps'         => $this->stepsFor((int) $path->id),
+            ],
+        ]);
+    }
+
+    /** POST /competency/career-paths */
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), $this->pathRules(true));
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $pathId = DB::table(self::PATHS)->insertGetId([
+            'sub_institute_id' => $sid,
+            'name'             => $request->input('name'),
+            'description'      => $request->input('description'),
+            'department_id'    => $request->input('department_id'),
+            'department'       => $request->input('department'),
+            'job_family'       => $request->input('job_family'),
+            'status'           => $request->input('status', 'active'),
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->replaceSteps($pathId, $sid, $request->input('steps', []), $context['user_id']);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'created_career_path',
+            'Created career path "' . $request->input('name') . '"',
+            'career_path',
+            $pathId,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Career path created successfully',
+            'data'    => ['id' => $pathId],
+        ], 201);
+    }
+
+    /** PUT /competency/career-paths/{id} */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $path = $this->findPath($id, $sid);
+        if (!$path) {
+            return response()->json(['status' => 0, 'message' => 'Career path not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), $this->pathRules(false));
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = ['updated_by' => $context['user_id'], 'updated_at' => now()];
+        foreach (['name', 'description', 'department_id', 'department', 'job_family', 'status'] as $field) {
+            if ($request->has($field)) {
+                $update[$field] = $request->input($field);
+            }
+        }
+
+        DB::table(self::PATHS)->where('id', $path->id)->update($update);
+
+        if ($request->has('steps')) {
+            $this->replaceSteps((int) $path->id, $sid, $request->input('steps', []), $context['user_id']);
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_career_path',
+            'Updated career path "' . ($update['name'] ?? $path->name) . '"',
+            'career_path',
+            (int) $path->id,
+            $update['name'] ?? $path->name
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Career path updated successfully',
+            'data'    => ['id' => (int) $path->id],
+        ]);
+    }
+
+    /** DELETE /competency/career-paths/{id} */
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $path = $this->findPath($id, $sid);
+        if (!$path) {
+            return response()->json(['status' => 0, 'message' => 'Career path not found'], 404);
+        }
+
+        DB::table(self::PATHS)->where('id', $path->id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+        DB::table(self::STEPS)->where('career_path_id', $path->id)->update(['deleted_at' => now()]);
+
+        // Unlink plans so the detail panel does not point at a deleted path.
+        DB::table('s_competency_development_plans')
+            ->where('sub_institute_id', $sid)->where('career_path_id', $path->id)
+            ->update(['career_path_id' => null, 'updated_at' => now()]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'deleted_career_path',
+            'Deleted career path "' . $path->name . '"',
+            'career_path',
+            (int) $path->id,
+            $path->name
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Career path deleted successfully']);
+    }
+
+    /* ================================================================== *
+     * Explorer
+     * ================================================================== */
+
+    /**
+     * GET /competency/career-paths/explorer
+     *
+     * Powers the Career Path Explorer card. Resolution order:
+     *   1. explicit ?career_path_id=      - the named path's own steps
+     *   2. ?plan_id=                      - that plan's linked path, else the
+     *                                       employee's role walked through
+     *                                       career_journey
+     *   3. the tenant's most recent path
+     * Each node past the current role carries match_percent for the employee in
+     * scope (when one can be resolved).
+     */
+    public function explorer(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $employeeId = null;
+        $currentRole = null;
+        $path = null;
+
+        if ($planId = $this->activeFilter($request->input('plan_id'))) {
+            $plan = DB::table('s_competency_development_plans')
+                ->where('id', $planId)->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+            if ($plan) {
+                $employeeId = $plan->user_id;
+                $currentRole = $plan->jobrole;
+                if ($plan->career_path_id) {
+                    $path = $this->findPath($plan->career_path_id, $sid);
+                }
+            }
+        }
+
+        if ($userId = $this->activeFilter($request->input('employee_id'))) {
+            $employeeId = (int) $userId;
+            $currentRole = null; // re-resolve below for the employee actually asked for
+        }
+
+        // Knowing the employee's own role is what lets the explorer mark the
+        // "(Current Role)" node and score the ones ahead of it.
+        if ($employeeId && !$currentRole) {
+            $currentRole = $this->roleForUser($sid, (int) $employeeId)->jobrole ?? null;
+        }
+
+        if (!$path && ($pathId = $this->activeFilter($request->input('career_path_id')))) {
+            $path = $this->findPath($pathId, $sid);
+        }
+
+        $source = 'career_path';
+        $nodes = [];
+
+        if ($path) {
+            $nodes = $this->stepsFor((int) $path->id);
+        } else {
+            // No named path: walk the tenant's progression graph from the
+            // employee's current role, exactly as CareerJourneyController does.
+            [$nodes, $source, $currentRole] = $this->derivePath($sid, $employeeId, $currentRole);
+
+            if (!$nodes) {
+                $path = DB::table(self::PATHS)
+                    ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+                    ->where('status', '!=', 'archived')->orderByDesc('id')->first();
+                if ($path) {
+                    $nodes = $this->stepsFor((int) $path->id);
+                    $source = 'career_path';
+                }
+            }
+        }
+
+        $held = $employeeId ? $this->heldLevels((int) $employeeId) : [];
+
+        // Without an employee to anchor on, honour the step the author marked
+        // as "current" rather than pretending the whole path lies ahead.
+        $matchedCurrent = false;
+        if ($currentRole) {
+            foreach ($nodes as $node) {
+                if (strcasecmp((string) $node['jobrole'], (string) $currentRole) === 0) {
+                    $matchedCurrent = true;
+                    break;
+                }
+            }
+        }
+
+        foreach ($nodes as $index => $node) {
+            $isCurrent = $matchedCurrent
+                ? strcasecmp((string) $node['jobrole'], (string) $currentRole) === 0
+                : ($node['step_type'] ?? '') === 'current';
+
+            $nodes[$index]['is_current'] = $isCurrent;
+            $nodes[$index]['step_type'] = $isCurrent ? 'current' : 'future';
+            $nodes[$index]['match_percent'] = $isCurrent ? 100 : $this->matchPercent($sid, (string) $node['jobrole'], $held);
+            $nodes[$index]['required_skills'] = $this->requiredCount($sid, (string) $node['jobrole']);
+        }
+
+        // The immediate next role is the first node AFTER the current one -
+        // never one behind it. With no current node at all, it is the first.
+        $currentIndex = null;
+        foreach ($nodes as $index => $node) {
+            if ($node['is_current']) {
+                $currentIndex = $index;
+                break;
+            }
+        }
+        for ($index = ($currentIndex === null ? 0 : $currentIndex + 1); $index < count($nodes); $index++) {
+            if (!$nodes[$index]['is_current']) {
+                $nodes[$index]['step_type'] = 'next';
+                break;
+            }
+        }
+
+        // Anything before the current role has already been held - label it so
+        // the card does not present it as a step still to come.
+        for ($index = 0; $index < ($currentIndex ?? 0); $index++) {
+            $nodes[$index]['step_type'] = 'past';
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Career path explorer fetched successfully',
+            'data'    => [
+                'career_path_id' => $path ? (int) $path->id : null,
+                'name'           => $path->name ?? ($currentRole ? $currentRole . ' Progression' : 'Career Path'),
+                'current_role'   => $currentRole,
+                'employee_id'    => $employeeId ? (int) $employeeId : null,
+                'source'         => $source,
+                'nodes'          => array_values($nodes),
+                'lateral_roles'  => $this->lateralRoles($sid, $currentRole, $held),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/career-paths/role-options
+     * Job roles available as path steps, plus the roles career_journey says can
+     * follow a given ?from_jobrole= (authoring aid for Create Career Path).
+     */
+    public function roleOptions(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $query = DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->whereNotNull('jobrole')->where('jobrole', '!=', '');
+
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('jobrole', 'like', "%{$search}%");
+        }
+        if ($departmentId = $this->activeFilter($request->input('department_id'))) {
+            $query->where('department_id', $departmentId);
+        }
+
+        $roles = $query->orderBy('jobrole')->limit(500)
+            ->get(['id', 'jobrole', 'job_level', 'department', 'department_id'])
+            ->unique('jobrole')->values()
+            ->map(fn ($r) => [
+                'id'            => (int) $r->id,
+                'jobrole'       => $r->jobrole,
+                'job_level'     => $r->job_level,
+                'department'    => $r->department,
+                'department_id' => $r->department_id ? (int) $r->department_id : null,
+            ])->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Role options fetched successfully',
+            'data'    => $roles,
+        ]);
+    }
+
+    /* ================================================================== *
+     * Helpers
+     * ================================================================== */
+
+    private function pathRules(bool $creating): array
+    {
+        return [
+            'name'          => ($creating ? 'required' : 'sometimes|required') . '|string|max:191',
+            'description'   => 'nullable|string',
+            'department_id' => 'nullable|integer',
+            'department'    => 'nullable|string|max:191',
+            'job_family'    => 'nullable|string|max:191',
+            'status'        => 'nullable|in:draft,active,archived',
+            'steps'                => 'nullable|array',
+            'steps.*.jobrole'      => 'required_with:steps|string|max:191',
+            'steps.*.jobrole_id'   => 'nullable|integer',
+            'steps.*.job_level'    => 'nullable|string|max:191',
+            'steps.*.step_type'    => 'nullable|in:current,next,future',
+            'steps.*.description'  => 'nullable|string',
+        ];
+    }
+
+    private function findPath($id, int $sid)
+    {
+        return DB::table(self::PATHS)
+            ->where('id', $id)->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+    }
+
+    /** Steps are replaced wholesale - the editor always submits the full list. */
+    private function replaceSteps(int $pathId, int $sid, $steps, ?int $actorId): void
+    {
+        DB::table(self::STEPS)->where('career_path_id', $pathId)->whereNull('deleted_at')
+            ->update(['deleted_at' => now()]);
+
+        if (!is_array($steps) || !$steps) {
+            return;
+        }
+
+        $rows = [];
+        foreach (array_values($steps) as $order => $step) {
+            $jobrole = trim((string) ($step['jobrole'] ?? ''));
+            if ($jobrole === '') {
+                continue;
+            }
+            // Editors submit role names; resolve the id so the step still joins
+            // s_user_jobrole for job_level and required-skill counts.
+            $role = ($step['jobrole_id'] ?? null) ? null : $this->roleByName($sid, $jobrole);
+
+            $rows[] = [
+                'sub_institute_id' => $sid,
+                'career_path_id'   => $pathId,
+                'jobrole_id'       => $step['jobrole_id'] ?? ($role->id ?? null),
+                'jobrole'          => $jobrole,
+                'job_level'        => $step['job_level'] ?? ($role->job_level ?? null),
+                'step_order'       => $order,
+                'step_type'        => $step['step_type'] ?? ($order === 0 ? 'current' : ($order === 1 ? 'next' : 'future')),
+                'description'      => $step['description'] ?? null,
+                'created_by'       => $actorId,
+                'created_at'       => now(),
+                'updated_at'       => now(),
+            ];
+        }
+
+        if ($rows) {
+            DB::table(self::STEPS)->insert($rows);
+        }
+    }
+
+    private function stepsFor(int $pathId): array
+    {
+        return DB::table(self::STEPS)
+            ->where('career_path_id', $pathId)->whereNull('deleted_at')
+            ->orderBy('step_order')->orderBy('id')->get()
+            ->map(fn ($s) => [
+                'id'          => (int) $s->id,
+                'jobrole'     => $s->jobrole,
+                'jobrole_id'  => $s->jobrole_id ? (int) $s->jobrole_id : null,
+                'job_level'   => $s->job_level,
+                'step_order'  => (int) $s->step_order,
+                'step_type'   => $s->step_type,
+                'description' => $s->description,
+            ])->all();
+    }
+
+    /**
+     * Walk career_journey (vertical edges) from the employee's current role.
+     * Falls back to s_user_jobrole.related_jobrole, then to other roles in the
+     * same department - the same ladder of fallbacks
+     * EmployeeCompetencyProfileController@careerPath already uses, because this
+     * tenant does not populate every progression edge.
+     *
+     * @return array{0:array,1:string,2:?string}
+     */
+    private function derivePath(int $sid, $employeeId, ?string $currentRole): array
+    {
+        $role = $currentRole ? $this->roleByName($sid, $currentRole) : null;
+
+        if (!$role && $employeeId) {
+            $role = $this->roleForUser($sid, (int) $employeeId);
+            $currentRole = $role->jobrole ?? $currentRole;
+        }
+
+        if (!$role) {
+            return [[], 'none', $currentRole];
+        }
+
+        $nodes = [[
+            'jobrole'     => $role->jobrole,
+            'jobrole_id'  => (int) $role->id,
+            'job_level'   => $role->job_level,
+            'step_order'  => 0,
+            'step_type'   => 'current',
+            'description' => null,
+        ]];
+
+        // 1. career_journey vertical chain
+        $visited = [(int) $role->id];
+        $cursor = (int) $role->id;
+        while (count($nodes) < 6) {
+            $edge = DB::table('career_journey as cj')
+                ->join('s_user_jobrole as jr', 'jr.id', '=', 'cj.to_jobrole_id')
+                ->where('cj.sub_institute_id', $sid)
+                ->where('cj.jobrole_id', $cursor)
+                ->where('cj.vertical_lateral_movement', 1)
+                ->whereNull('jr.deleted_at')
+                ->orderBy('jr.sequence_order')->orderBy('cj.id')
+                ->first(['jr.id', 'jr.jobrole', 'jr.job_level']);
+
+            if (!$edge || in_array((int) $edge->id, $visited, true)) {
+                break;
+            }
+
+            $visited[] = (int) $edge->id;
+            $nodes[] = [
+                'jobrole'     => $edge->jobrole,
+                'jobrole_id'  => (int) $edge->id,
+                'job_level'   => $edge->job_level,
+                'step_order'  => count($nodes),
+                'step_type'   => 'future',
+                'description' => null,
+            ];
+            $cursor = (int) $edge->id;
+        }
+
+        if (count($nodes) > 1) {
+            return [$nodes, 'career_journey', $currentRole];
+        }
+
+        // 1b. Nothing ahead - this role is the top of its track. Walk the graph
+        // BACKWARDS instead so the card shows the ladder that leads up to the
+        // current role (which stays last) rather than listing junior roles as
+        // if they were still to come.
+        $prefix = [];
+        $cursor = (int) $role->id;
+        while (count($prefix) < 4) {
+            $edge = DB::table('career_journey as cj')
+                ->join('s_user_jobrole as jr', 'jr.id', '=', 'cj.jobrole_id')
+                ->where('cj.sub_institute_id', $sid)
+                ->where('cj.to_jobrole_id', $cursor)
+                ->where('cj.vertical_lateral_movement', 1)
+                ->whereNull('jr.deleted_at')
+                ->orderByDesc('jr.sequence_order')->orderBy('cj.id')
+                ->first(['jr.id', 'jr.jobrole', 'jr.job_level']);
+
+            if (!$edge || in_array((int) $edge->id, $visited, true)) {
+                break;
+            }
+
+            $visited[] = (int) $edge->id;
+            array_unshift($prefix, [
+                'jobrole'     => $edge->jobrole,
+                'jobrole_id'  => (int) $edge->id,
+                'job_level'   => $edge->job_level,
+                'step_type'   => 'future',
+                'description' => null,
+            ]);
+            $cursor = (int) $edge->id;
+        }
+
+        if ($prefix) {
+            $nodes = array_merge($prefix, $nodes);
+            foreach ($nodes as $index => $node) {
+                $nodes[$index]['step_order'] = $index;
+            }
+            return [$nodes, 'career_journey', $currentRole];
+        }
+
+        // 2. related_jobrole, 3. same department
+        $names = [];
+        $source = 'related';
+        if (!empty($role->related_jobrole)) {
+            $names = array_values(array_unique(array_filter(array_map('trim', explode(',', $role->related_jobrole)))));
+        }
+        if (!$names && !empty($role->department)) {
+            $names = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+                ->where('department', $role->department)
+                ->where('jobrole', '!=', $role->jobrole)
+                ->whereNotNull('jobrole')->where('jobrole', '!=', '')
+                ->distinct()->orderBy('sequence_order')->orderBy('jobrole')
+                ->limit(3)->pluck('jobrole')->all();
+            $source = 'department';
+        }
+
+        foreach (array_slice($names, 0, 3) as $name) {
+            $next = $this->roleByName($sid, $name);
+            $nodes[] = [
+                'jobrole'     => $name,
+                'jobrole_id'  => $next ? (int) $next->id : null,
+                'job_level'   => $next->job_level ?? null,
+                'step_order'  => count($nodes),
+                'step_type'   => 'future',
+                'description' => null,
+            ];
+        }
+
+        return [$nodes, count($nodes) > 1 ? $source : 'none', $currentRole];
+    }
+
+    /** Lateral moves - preserved from the old frontend's Succession screen. */
+    private function lateralRoles(int $sid, ?string $currentRole, array $held): array
+    {
+        if (!$currentRole) {
+            return [];
+        }
+        $role = $this->roleByName($sid, $currentRole);
+        if (!$role) {
+            return [];
+        }
+
+        return DB::table('career_journey as cj')
+            ->join('s_user_jobrole as jr', 'jr.id', '=', 'cj.to_jobrole_id')
+            ->where('cj.sub_institute_id', $sid)
+            ->where('cj.jobrole_id', $role->id)
+            ->where('cj.vertical_lateral_movement', 0)
+            ->whereNull('jr.deleted_at')
+            ->orderBy('jr.sequence_order')->limit(6)
+            ->get(['jr.id', 'jr.jobrole', 'jr.job_level'])
+            ->unique('jobrole')->values()
+            ->map(fn ($r) => [
+                'jobrole'       => $r->jobrole,
+                'jobrole_id'    => (int) $r->id,
+                'job_level'     => $r->job_level,
+                'match_percent' => $this->matchPercent($sid, (string) $r->jobrole, $held),
+            ])->all();
+    }
+
+    private function roleByName(int $sid, string $name)
+    {
+        return DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)->where('jobrole', $name)->whereNull('deleted_at')->first();
+    }
+
+    /**
+     * Resolve an employee's current role. tbluser.jobtitle_id is 0 on some
+     * tenants, so fall back to allocated_standards (a role id) and then to the
+     * jobrole on their most recent assessment.
+     */
+    private function roleForUser(int $sid, int $userId)
+    {
+        $user = DB::table('tbluser')->where('id', $userId)->where('sub_institute_id', $sid)->first();
+        if (!$user) {
+            return null;
+        }
+
+        foreach ([$user->jobtitle_id ?? null, $this->firstNumeric($user->allocated_standards ?? null)] as $roleId) {
+            if ($roleId) {
+                $role = DB::table('s_user_jobrole')->where('id', $roleId)
+                    ->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+                if ($role) {
+                    return $role;
+                }
+            }
+        }
+
+        $recent = DB::table('s_competency_assessments')
+            ->where('sub_institute_id', $sid)->where('user_id', $userId)->whereNull('deleted_at')
+            ->whereNotNull('jobrole')->where('jobrole', '!=', '')->orderByDesc('id')->first();
+
+        return $recent ? $this->roleByName($sid, $recent->jobrole) : null;
+    }
+
+    private function firstNumeric($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        foreach (array_map('trim', explode(',', (string) $value)) as $part) {
+            if (is_numeric($part)) {
+                return (int) $part;
+            }
+        }
+        return null;
+    }
+
+    /** @return array<string,int> skill title => level the employee holds */
+    private function heldLevels(int $userId): array
+    {
+        return DB::table('s_skill_matrix as m')
+            ->join('s_users_skills as s', 'm.skill_id', '=', 's.id')
+            ->where('m.user_id', $userId)
+            ->whereNull('m.deleted_at')->whereNull('s.deleted_at')
+            ->pluck('m.skill_level', 's.title')
+            ->map(fn ($v) => (int) $v)
+            ->all();
+    }
+
+    /**
+     * Readiness for a target role: the share of its required proficiency the
+     * employee already holds, capped per competency so one over-qualified skill
+     * cannot mask several missing ones.
+     */
+    private function matchPercent(int $sid, string $jobrole, array $held): ?int
+    {
+        if (!$held) {
+            return null;
+        }
+
+        $required = DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)->where('jobrole', $jobrole)->whereNull('deleted_at')
+            ->get(['skill', 'proficiency_level']);
+
+        if ($required->isEmpty()) {
+            return null;
+        }
+
+        $needed = 0;
+        $have = 0;
+        foreach ($required as $row) {
+            $level = (int) $row->proficiency_level;
+            if ($level <= 0) {
+                continue;
+            }
+            $needed += $level;
+            $have += min((int) ($held[$row->skill] ?? 0), $level);
+        }
+
+        return $needed > 0 ? (int) round($have / $needed * 100) : null;
+    }
+
+    private function requiredCount(int $sid, string $jobrole): int
+    {
+        return DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)->where('jobrole', $jobrole)->whereNull('deleted_at')
+            ->distinct()->count('skill');
+    }
+}

--- a/app/Http/Controllers/Api/Competency/CertificationController.php
+++ b/app/Http/Controllers/Api/Competency/CertificationController.php
@@ -1,0 +1,1640 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Certifications (s_competency_certifications) for the Certification &
+ * Compliance Center.
+ *
+ * index/store/destroy already backed the Command Center's "Add Certification"
+ * quick action and its Certifications tile; the compliance center additionally
+ * needs KPI metrics, filter options, a single credential's detail, edit /
+ * verify / revoke, bulk actions, export, the requirement + compliance view
+ * behind a credential, its documents (stored on the shared evidence table) and
+ * its history.
+ *
+ * All of it is additive - index() keeps the same route and the same
+ * {status,message,data,pagination} envelope and only widens the row shape and
+ * the accepted filters, so existing consumers keep reading what they read
+ * before.
+ */
+class CertificationController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    private const TABLE = 's_competency_certifications';
+    private const REQUIREMENTS = 's_competency_certification_requirements';
+    private const EVIDENCE = 's_competency_evidence';
+
+    /**
+     * How near an expiry has to be before the credential counts as "Expiring
+     * Soon". 60 days is what this screen's KPI card states; the Command Center's
+     * work queue deliberately uses a tighter 30-day window, so the two figures
+     * are expected to differ.
+     */
+    private const EXPIRING_WINDOW_DAYS = 60;
+
+    /** Raw DB status -> the label the screen renders. */
+    private const STATUS_LABELS = [
+        'valid'    => 'Active',
+        'expiring' => 'Expiring',
+        'expired'  => 'Expired',
+        'revoked'  => 'Revoked',
+    ];
+
+    private const SORTABLE = [
+        'name'         => 'name',
+        'status'       => 'status',
+        'issued_date'  => 'issued_date',
+        'expiry_date'  => 'expiry_date',
+        'created_at'   => 'created_at',
+    ];
+
+    /**
+     * Columns worth reporting in the Audit Center's Change Summary, with the
+     * label that card shows. Bookkeeping columns (updated_by/_at, verified_by/_at)
+     * are deliberately absent - they change on every edit and would bury the
+     * change the reader is actually looking for.
+     */
+    private const CHANGE_LABELS = [
+        'name'                => 'Certification Name',
+        'user_id'             => 'Holder',
+        'competency_id'       => 'Linked Competency',
+        'requirement_id'      => 'Requirement',
+        'issuing_body'        => 'Issuing Body',
+        'certification_type'  => 'Certification Type',
+        'credential_id'       => 'Credential ID',
+        'department_id'       => 'Department',
+        'jobrole'             => 'Job Role',
+        'status'              => 'Status',
+        'verification_status' => 'Verification Status',
+        'issued_date'         => 'Issued Date',
+        'expiry_date'         => 'Expiry Date',
+        'notes'               => 'Notes',
+    ];
+
+    /* ================================================================== *
+     * List
+     * ================================================================== */
+
+    /**
+     * GET /competency/certifications
+     *
+     * Filters: status, search (name / credential id / employee name),
+     *          compliance=compliant|expiring|non_compliant,
+     *          expiry_window=30|60|90|expired, department_id, jobrole,
+     *          certification_type, issuing_body, verification_status,
+     *          user_id_filter (the "My Certifications" tab),
+     *          issued_from, issued_to, expiry_from, expiry_to
+     * Sort:    sort=name|status|issued_date|expiry_date|created_at, direction=asc|desc
+     */
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 15), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = $this->filteredQuery($request, $sid);
+        $total = (clone $query)->count();
+
+        $sortKey = (string) $request->input('sort', 'created_at');
+        $column = self::SORTABLE[$sortKey] ?? 'id';
+        $direction = strtolower((string) $request->input('direction', 'desc')) === 'asc' ? 'asc' : 'desc';
+
+        $rows = $query->orderBy($column, $direction)->orderByDesc('id')
+            ->forPage($page, $perPage)->get();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Certifications fetched successfully',
+            'data'       => $this->decorateRows($rows, $sid),
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/certifications/export
+     *
+     * Every row matching the current filters, uncapped, for the header's Export
+     * button (the CSV itself is assembled client side so no new dependency is
+     * needed). Hard limit of 5000 rows keeps a runaway export bounded.
+     */
+    public function export(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $rows = $this->filteredQuery($request, $sid)->orderByDesc('id')->limit(5000)->get();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certifications exported successfully',
+            'data'    => $this->decorateRows($rows, $sid),
+        ]);
+    }
+
+    /**
+     * GET /competency/certifications/metrics
+     *
+     * The screen's five KPI cards.
+     */
+    public function metrics(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $base = fn () => DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        $today = now()->toDateString();
+        $window = now()->addDays(self::EXPIRING_WINDOW_DAYS)->toDateString();
+
+        $total = (clone $base())->count();
+
+        // Expiring soon: still live, expiry inside the window.
+        $expiringSoon = (clone $base())
+            ->whereNotIn('status', ['revoked', 'expired'])
+            ->whereNotNull('expiry_date')
+            ->whereBetween('expiry_date', [$today, $window])
+            ->count();
+
+        // Expired: flagged expired, or the date has simply passed.
+        $expired = (clone $base())
+            ->where('status', '!=', 'revoked')
+            ->where(function ($q) use ($today) {
+                $q->where('status', 'expired')
+                    ->orWhere(function ($inner) use ($today) {
+                        $inner->whereNotNull('expiry_date')->where('expiry_date', '<', $today);
+                    });
+            })
+            ->count();
+
+        $pendingVerification = (clone $base())->where('verification_status', 'pending')->count();
+
+        $compliance = $this->employeeCompliance($sid);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification metrics fetched successfully',
+            'data'    => [
+                'total'                  => $total,
+                'compliant_employees'    => $compliance['compliant'],
+                'employees_evaluated'    => $compliance['universe'],
+                'compliant_percent'      => $compliance['percent'],
+                'expiring_soon'          => $expiringSoon,
+                'expiring_window_days'   => self::EXPIRING_WINDOW_DAYS,
+                'expired'                => $expired,
+                'pending_verification'   => $pendingVerification,
+                'revoked'                => (clone $base())->where('status', 'revoked')->count(),
+                'verified'               => (clone $base())->where('verification_status', 'verified')->count(),
+                'requirements'           => DB::table(self::REQUIREMENTS)
+                    ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+                    ->where('status', 'active')->count(),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/certifications/filters
+     *
+     * Options for the Department / Certification Type / Issuing Body selects.
+     * Only values that actually occur in this tenant's data, so a filter can
+     * never produce an empty result set.
+     */
+    public function filters(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $base = fn () => DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at');
+
+        $departmentIds = (clone $base())->whereNotNull('department_id')
+            ->distinct()->pluck('department_id')->all();
+
+        $departments = [];
+        if ($departmentIds) {
+            $names = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->whereIn('department_id', $departmentIds)
+                ->whereNull('deleted_at')
+                ->pluck('department', 'department_id')
+                ->all();
+
+            foreach ($departmentIds as $id) {
+                $departments[] = [
+                    'value' => (string) $id,
+                    'label' => $names[$id] ?? ('Department ' . $id),
+                ];
+            }
+            usort($departments, fn ($a, $b) => strcasecmp($a['label'], $b['label']));
+        }
+
+        $simpleList = function (string $column) use ($base) {
+            $values = (clone $base())->whereNotNull($column)->where($column, '!=', '')
+                ->distinct()->orderBy($column)->pluck($column)->all();
+
+            return array_map(fn ($v) => ['value' => (string) $v, 'label' => (string) $v], $values);
+        };
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification filters fetched successfully',
+            'data'    => [
+                'departments'         => $departments,
+                'certification_types' => $simpleList('certification_type'),
+                'issuing_bodies'      => $simpleList('issuing_body'),
+                'jobroles'            => $simpleList('jobrole'),
+                'statuses'            => [
+                    ['value' => 'valid', 'label' => 'Active'],
+                    ['value' => 'expiring', 'label' => 'Expiring'],
+                    ['value' => 'expired', 'label' => 'Expired'],
+                    ['value' => 'revoked', 'label' => 'Revoked'],
+                ],
+                'compliance'          => [
+                    ['value' => 'compliant', 'label' => 'Compliant'],
+                    ['value' => 'expiring', 'label' => 'Expiring Soon'],
+                    ['value' => 'non_compliant', 'label' => 'Non-Compliant'],
+                ],
+                'expiry_windows'      => [
+                    ['value' => '30', 'label' => 'Next 30 days'],
+                    ['value' => '60', 'label' => 'Next 60 days'],
+                    ['value' => '90', 'label' => 'Next 90 days'],
+                    ['value' => 'expired', 'label' => 'Already expired'],
+                ],
+                'verification'        => [
+                    ['value' => 'pending', 'label' => 'Pending Verification'],
+                    ['value' => 'verified', 'label' => 'Verified'],
+                    ['value' => 'rejected', 'label' => 'Rejected'],
+                ],
+            ],
+        ]);
+    }
+
+    /* ================================================================== *
+     * Single credential
+     * ================================================================== */
+
+    /**
+     * GET /competency/certifications/{id}
+     *
+     * The side panel's Overview tab: the credential, the employee behind it and
+     * the derived compliance / days-to-expiry figures.
+     */
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->findCertification($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $data = $this->decorateRows(collect([$row]), $sid)[0];
+        $data['employee'] = $row->user_id ? $this->employeeCard((int) $row->user_id, $sid) : null;
+        $data['requirement'] = $row->requirement_id
+            ? DB::table(self::REQUIREMENTS)->where('id', $row->requirement_id)
+                ->where('sub_institute_id', $sid)->whereNull('deleted_at')->first()
+            : null;
+        $data['competency'] = $row->competency_id
+            ? DB::table('s_users_skills')->where('id', $row->competency_id)->value('title')
+            : null;
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'                => 'required|string|max:191',
+            // user_id stays accepted for the two existing consumers (the
+            // command-center quick create and employeeProfileService
+            // .addCertification, which both post the holder as user_id).
+            // user_id_target is the unambiguous form and wins when both arrive.
+            'user_id'             => 'nullable|integer',
+            'user_id_target'      => 'nullable|integer',
+            'competency_id'       => 'nullable|integer',
+            'requirement_id'      => 'nullable|integer',
+            'issuing_body'        => 'nullable|string|max:191',
+            'certification_type'  => 'nullable|string|max:100',
+            'credential_id'       => 'nullable|string|max:191',
+            'department_id'       => 'nullable|integer',
+            'jobrole'             => 'nullable|string|max:191',
+            'status'              => 'nullable|in:valid,expiring,expired,revoked',
+            'verification_status' => 'nullable|in:pending,verified,rejected',
+            'issued_date'         => 'nullable|date',
+            'expiry_date'         => 'nullable|date',
+            'notes'               => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table(self::TABLE)->insertGetId([
+            'sub_institute_id'    => $context['sub_institute_id'],
+            'name'                => $request->input('name'),
+            'user_id'             => $request->input('user_id_target') ?: $request->input('user_id'),
+            'competency_id'       => $request->input('competency_id'),
+            'requirement_id'      => $request->input('requirement_id'),
+            'issuing_body'        => $request->input('issuing_body'),
+            'certification_type'  => $request->input('certification_type'),
+            'credential_id'       => $request->input('credential_id'),
+            'department_id'       => $request->input('department_id'),
+            'jobrole'             => $request->input('jobrole'),
+            'status'              => $request->input('status', 'valid'),
+            'verification_status' => $request->input('verification_status', 'pending'),
+            'issued_date'         => $request->input('issued_date'),
+            'expiry_date'         => $request->input('expiry_date'),
+            'notes'               => $request->input('notes'),
+            'created_by'          => $context['user_id'],
+            'updated_by'          => $context['user_id'],
+            'created_at'          => now(),
+            'updated_at'          => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'added_certification',
+            'Added certification "' . $request->input('name') . '"',
+            'certification',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    /**
+     * PUT /competency/certifications/{id}
+     *
+     * Backs Edit, the row menu's "Update Status" and "Revoke", and the
+     * Verify / Reject verification actions. Only the keys actually present in
+     * the request are written, so a status-only call cannot blank the rest.
+     */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $existing = $this->findCertification($id, $sid);
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'                => 'sometimes|required|string|max:191',
+            // NB: the credential's holder travels as user_id_target. Plain
+            // user_id is the CONTEXT ACTOR on every /competency/* call, so
+            // accepting it here would silently reassign the credential to
+            // whoever performed the update.
+            'user_id_target'      => 'sometimes|nullable|integer',
+            'competency_id'       => 'sometimes|nullable|integer',
+            'requirement_id'      => 'sometimes|nullable|integer',
+            'issuing_body'        => 'sometimes|nullable|string|max:191',
+            'certification_type'  => 'sometimes|nullable|string|max:100',
+            'credential_id'       => 'sometimes|nullable|string|max:191',
+            'department_id'       => 'sometimes|nullable|integer',
+            'jobrole'             => 'sometimes|nullable|string|max:191',
+            'status'              => 'sometimes|required|in:valid,expiring,expired,revoked',
+            'verification_status' => 'sometimes|required|in:pending,verified,rejected',
+            'issued_date'         => 'sometimes|nullable|date',
+            'expiry_date'         => 'sometimes|nullable|date',
+            'notes'               => 'sometimes|nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $fields = ['name', 'competency_id', 'requirement_id', 'issuing_body',
+            'certification_type', 'credential_id', 'department_id', 'jobrole', 'status',
+            'verification_status', 'issued_date', 'expiry_date', 'notes'];
+
+        $update = ['updated_by' => $context['user_id'], 'updated_at' => now()];
+        foreach ($fields as $field) {
+            if ($request->has($field)) {
+                $update[$field] = $request->input($field);
+            }
+        }
+        // Reassigning the holder is deliberate and explicit only.
+        if ($request->has('user_id_target')) {
+            $update['user_id'] = $request->input('user_id_target');
+        }
+
+        // Stamp who signed the credential off whenever verification moves on.
+        if ($request->has('verification_status')) {
+            $newState = $request->input('verification_status');
+            $update['verified_by'] = $newState === 'pending' ? null : $context['user_id'];
+            $update['verified_at'] = $newState === 'pending' ? null : now();
+        }
+
+        DB::table(self::TABLE)->where('id', $id)->update($update);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            $this->updateAction($request),
+            $this->updateDescription($request, $existing->name),
+            'certification',
+            (int) $id,
+            $existing->name,
+            // Field-level diff for the Audit Center's Change Summary card.
+            $this->diffChanges($existing, $update, self::CHANGE_LABELS)
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification updated successfully',
+            'data'    => ['id' => (int) $id],
+        ]);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $existing = $this->findCertification($id, $context['sub_institute_id']);
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        DB::table(self::TABLE)->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_certification',
+            'Deleted certification "' . $existing->name . '"',
+            'certification',
+            (int) $id,
+            $existing->name
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Certification deleted successfully']);
+    }
+
+    /**
+     * POST /competency/certifications/bulk
+     *
+     * The table's "Bulk Actions" menu over the checkbox selection.
+     * action = verify | reject | update_status | revoke | delete
+     */
+    public function bulk(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'action' => 'required|in:verify,reject,update_status,revoke,delete',
+            'ids'    => 'required|array|min:1',
+            'ids.*'  => 'integer',
+            'status' => 'required_if:action,update_status|nullable|in:valid,expiring,expired,revoked',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $action = $request->input('action');
+        $ids = array_values(array_unique(array_map('intval', $request->input('ids'))));
+
+        // Tenant guard: only ever touch rows this tenant owns.
+        $ownedIds = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->whereIn('id', $ids)->pluck('id')->all();
+
+        if (!$ownedIds) {
+            return response()->json(['status' => 0, 'message' => 'No matching certifications found'], 404);
+        }
+
+        $update = ['updated_by' => $context['user_id'], 'updated_at' => now()];
+
+        switch ($action) {
+            case 'verify':
+                $update += ['verification_status' => 'verified', 'verified_by' => $context['user_id'], 'verified_at' => now()];
+                $label = 'Verified';
+                break;
+            case 'reject':
+                $update += ['verification_status' => 'rejected', 'verified_by' => $context['user_id'], 'verified_at' => now()];
+                $label = 'Rejected';
+                break;
+            case 'revoke':
+                $update += ['status' => 'revoked'];
+                $label = 'Revoked';
+                break;
+            case 'update_status':
+                $update += ['status' => $request->input('status')];
+                $label = 'Status updated for';
+                break;
+            default: // delete
+                $update += ['deleted_at' => now(), 'deleted_by' => $context['user_id']];
+                $label = 'Deleted';
+                break;
+        }
+
+        DB::table(self::TABLE)->whereIn('id', $ownedIds)->update($update);
+
+        $count = count($ownedIds);
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'bulk_' . $action . '_certifications',
+            $label . ' ' . $count . ' certification' . ($count === 1 ? '' : 's'),
+            'certification',
+            null,
+            $count . ' certification' . ($count === 1 ? '' : 's')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => $label . ' ' . $count . ' certification' . ($count === 1 ? '' : 's'),
+            'data'    => ['affected' => $count],
+        ]);
+    }
+
+    /**
+     * POST /competency/certifications/{id}/notes
+     *
+     * The Overview panel's Notes "+" action. Notes are appended as dated lines
+     * on the credential's notes column rather than living in their own table.
+     */
+    public function addNote(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $existing = $this->findCertification($id, $sid);
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), ['note' => 'required|string|max:2000']);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $author = $context['user_id']
+            ? DB::table('tbluser')->where('id', $context['user_id'])->first()
+            : null;
+        $authorName = $author
+            ? (trim(($author->first_name ?? '') . ' ' . ($author->last_name ?? '')) ?: ($author->user_name ?? 'User'))
+            : 'System';
+
+        $line = '[' . now()->format('d M Y') . ' - ' . $authorName . '] ' . trim($request->input('note'));
+        $notes = trim((string) $existing->notes);
+        $notes = $notes === '' ? $line : $notes . "\n" . $line;
+
+        DB::table(self::TABLE)->where('id', $id)->update([
+            'notes'      => $notes,
+            'updated_by' => $context['user_id'],
+            'updated_at' => now(),
+        ]);
+
+        // Logged as a comment so the note surfaces in the Audit Center's
+        // Comments tab. The note text itself is the description, which is what
+        // that tab renders.
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'commented_certification',
+            trim($request->input('note')),
+            'certification',
+            (int) $id,
+            $existing->name
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Note added successfully',
+            'data'    => ['notes' => $notes],
+        ]);
+    }
+
+    /* ================================================================== *
+     * Side-panel tabs
+     * ================================================================== */
+
+    /**
+     * GET /competency/certifications/{id}/compliance
+     *
+     * The Compliance tab: where this credential sits in its validity window,
+     * whether it satisfies a mandatory requirement, and how the holder is doing
+     * overall.
+     */
+    public function compliance(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->findCertification($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $state = $this->complianceState($row);
+        $requirements = $this->requirementsFor($sid, $row->jobrole, $row->department_id);
+        $matched = $this->matchRequirement($requirements, $row->name, $row->requirement_id);
+
+        // Validity progress: how far through the issued -> expiry window we are.
+        $percentElapsed = null;
+        if ($row->issued_date && $row->expiry_date) {
+            $start = strtotime((string) $row->issued_date);
+            $end = strtotime((string) $row->expiry_date);
+            if ($end > $start) {
+                $percentElapsed = (int) min(100, max(0, round(((time() - $start) / ($end - $start)) * 100)));
+            }
+        }
+
+        // How the holder looks across every credential they hold.
+        $holder = null;
+        if ($row->user_id) {
+            $all = DB::table(self::TABLE)
+                ->where('sub_institute_id', $sid)->where('user_id', $row->user_id)
+                ->whereNull('deleted_at')->get();
+
+            $counts = ['compliant' => 0, 'expiring' => 0, 'non_compliant' => 0];
+            foreach ($all as $cert) {
+                $counts[$this->complianceState($cert)['key']]++;
+            }
+
+            $employeeCompliance = $this->employeeCompliance($sid, (int) $row->user_id);
+            $holder = [
+                'total'          => $all->count(),
+                'compliant'      => $counts['compliant'],
+                'expiring'       => $counts['expiring'],
+                'non_compliant'  => $counts['non_compliant'],
+                'is_compliant'   => $employeeCompliance['compliant'] > 0,
+                'missing'        => $employeeCompliance['missing'],
+            ];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Compliance fetched successfully',
+            'data'    => [
+                'compliance'          => $state['label'],
+                'compliance_key'      => $state['key'],
+                'reason'              => $state['reason'],
+                'days_to_expiry'      => $this->daysToExpiry($row->expiry_date),
+                'validity_percent'    => $percentElapsed,
+                'issued_date'         => $this->humanDate($row->issued_date),
+                'expiry_date'         => $this->humanDate($row->expiry_date),
+                'verification_status' => $row->verification_status,
+                'verified_at'         => $this->humanDate($row->verified_at),
+                'verified_by'         => $row->verified_by
+                    ? ($this->userMap([(int) $row->verified_by])[(int) $row->verified_by]['name'] ?? null)
+                    : null,
+                'requirement'         => $matched ? $this->requirementRow($matched) : null,
+                'is_required'         => (bool) $matched,
+                'window_days'         => self::EXPIRING_WINDOW_DAYS,
+                'holder'              => $holder,
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/certifications/{id}/requirements
+     *
+     * The Requirements tab: every requirement that applies to this credential's
+     * holder (their job role / department / org-wide), and whether they are met.
+     */
+    public function requirements(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->findCertification($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $requirements = $this->requirementsFor($sid, $row->jobrole, $row->department_id);
+
+        // What the holder currently has, to mark each requirement met / unmet.
+        $held = $row->user_id
+            ? DB::table(self::TABLE)
+                ->where('sub_institute_id', $sid)->where('user_id', $row->user_id)
+                ->whereNull('deleted_at')->get()
+            : collect();
+
+        $data = [];
+        foreach ($requirements as $requirement) {
+            $match = null;
+            foreach ($held as $cert) {
+                $sameRequirement = $cert->requirement_id && (int) $cert->requirement_id === (int) $requirement->id;
+                if ($sameRequirement || $this->sameName($cert->name, $requirement->name)) {
+                    $state = $this->complianceState($cert);
+                    // Prefer a genuinely compliant credential over a lapsed one.
+                    if (!$match || $state['key'] === 'compliant') {
+                        $match = ['cert' => $cert, 'state' => $state];
+                    }
+                }
+            }
+
+            $entry = $this->requirementRow($requirement);
+            $entry['is_met'] = $match !== null && $match['state']['key'] !== 'non_compliant';
+            $entry['held_certification_id'] = $match ? (int) $match['cert']->id : null;
+            $entry['held_status'] = $match ? $match['state']['label'] : 'Not Held';
+            $entry['held_expiry'] = $match ? $this->humanDate($match['cert']->expiry_date) : null;
+            $entry['is_current'] = $match ? ((int) $match['cert']->id === (int) $row->id) : false;
+            $data[] = $entry;
+        }
+
+        $met = count(array_filter($data, fn ($r) => $r['is_met']));
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Requirements fetched successfully',
+            'data'    => $data,
+            'summary' => [
+                'total'       => count($data),
+                'met'         => $met,
+                'unmet'       => count($data) - $met,
+                'mandatory'   => count(array_filter($data, fn ($r) => $r['is_mandatory'])),
+                'met_percent' => count($data) ? (int) round(($met / count($data)) * 100) : 0,
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/certifications/{id}/history
+     *
+     * The History tab, straight off the shared activity feed this controller
+     * already writes to.
+     */
+    public function history(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->findCertification($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $entries = DB::table('s_competency_activity_log')
+            ->where('sub_institute_id', $sid)
+            ->where('subject_type', 'certification')
+            ->where('subject_id', $id)
+            ->orderByDesc('id')
+            ->limit(100)
+            ->get();
+
+        $data = $entries->map(fn ($e) => [
+            'id'          => (int) $e->id,
+            'action'      => $e->action,
+            'description' => $e->description,
+            'by'          => $e->actor_name ?: 'System',
+            'date'        => $this->humanDate($e->created_at),
+            'at'          => $e->created_at,
+        ])->all();
+
+        // The credential's own audit stamps, so a row that predates the feed
+        // still shows something meaningful.
+        $users = $this->userMap(array_filter([$row->created_by, $row->updated_by, $row->verified_by]));
+        $stamps = [
+            ['label' => 'Certification recorded', 'by' => $row->created_by, 'at' => $row->created_at],
+            ['label' => 'Last updated', 'by' => $row->updated_by, 'at' => $row->updated_at],
+            ['label' => 'Verified', 'by' => $row->verified_by, 'at' => $row->verified_at],
+        ];
+
+        $audit = [];
+        foreach ($stamps as $stamp) {
+            if (!$stamp['at']) {
+                continue;
+            }
+            $audit[] = [
+                'label' => $stamp['label'],
+                'by'    => $stamp['by'] ? ($users[(int) $stamp['by']]['name'] ?? 'User ' . $stamp['by']) : 'System',
+                'date'  => $this->humanDate($stamp['at']),
+            ];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'History fetched successfully',
+            'data'    => $data,
+            'audit'   => $audit,
+        ]);
+    }
+
+    /* ================================================================== *
+     * Documents (stored on the shared s_competency_evidence table)
+     * ================================================================== */
+
+    /** GET /competency/certifications/{id}/documents */
+    public function documents(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->findCertification($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $rows = DB::table(self::EVIDENCE)
+            ->where('sub_institute_id', $sid)
+            ->where('certification_id', $id)
+            ->whereNull('deleted_at')
+            ->orderByDesc('id')
+            ->get();
+
+        $users = $this->userMap($rows->pluck('created_by')->filter()->all());
+
+        $data = $rows->map(fn ($r) => [
+            'id'            => (int) $r->id,
+            'title'         => $r->title,
+            'evidence_type' => $r->evidence_type,
+            'description'   => $r->description,
+            'link'          => $r->link,
+            'file_name'     => $r->file_name,
+            'file_url'      => $r->file_path ? $this->fileUrl($r->file_path) : null,
+            'url'           => $r->file_path ? $this->fileUrl($r->file_path) : $r->link,
+            'status'        => $r->status,
+            'uploaded_by'   => $r->created_by ? ($users[(int) $r->created_by]['name'] ?? null) : null,
+            'uploaded_on'   => $this->humanDate($r->created_at),
+        ])->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Documents fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * POST /competency/certifications/{id}/documents
+     *
+     * Accepts either an uploaded file (multipart `file`) or an external `link`.
+     * Uploads go to the same DigitalOcean Spaces disk the rest of the ERP uses.
+     */
+    public function storeDocument(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->findCertification($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Certification not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title'         => 'required|string|max:191',
+            'evidence_type' => 'nullable|in:certification,project,document,endorsement,training',
+            'description'   => 'nullable|string',
+            'link'          => 'nullable|string|max:500',
+            'file'          => 'nullable|file|max:10240|mimes:pdf,jpg,jpeg,png,doc,docx',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        if (!$request->hasFile('file') && !$this->activeFilter($request->input('link'))) {
+            return response()->json([
+                'status'  => 0,
+                'message' => 'Attach a file or provide a link',
+            ], 422);
+        }
+
+        $fileName = null;
+        $filePath = null;
+
+        if ($request->hasFile('file')) {
+            $file = $request->file('file');
+            $fileName = $file->getClientOriginalName();
+            $stored = time() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $fileName);
+            $filePath = 'public/competency_certifications/' . $stored;
+
+            try {
+                Storage::disk('digitalocean')->putFileAs('public/competency_certifications/', $file, $stored, 'public');
+            } catch (\Throwable $e) {
+                return response()->json([
+                    'status'  => 0,
+                    'message' => 'File upload failed: ' . $e->getMessage(),
+                ], 500);
+            }
+        }
+
+        $evidenceId = DB::table(self::EVIDENCE)->insertGetId([
+            'sub_institute_id' => $sid,
+            'user_id'          => $row->user_id ?: ($context['user_id'] ?? 0),
+            'competency_id'    => $row->competency_id,
+            'certification_id' => (int) $id,
+            'title'            => $request->input('title'),
+            'evidence_type'    => $request->input('evidence_type', 'certification'),
+            'description'      => $request->input('description'),
+            'link'             => $this->activeFilter($request->input('link')),
+            'file_name'        => $fileName,
+            'file_path'        => $filePath,
+            'status'           => 'pending',
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'added_certification_document',
+            'Attached document "' . $request->input('title') . '" to certification "' . $row->name . '"',
+            'certification',
+            (int) $id,
+            $request->input('title')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Document added successfully',
+            'data'    => ['id' => $evidenceId],
+        ], 201);
+    }
+
+    /** DELETE /competency/certifications/{id}/documents/{documentId} */
+    public function destroyDocument(Request $request, $id, $documentId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $document = DB::table(self::EVIDENCE)
+            ->where('id', $documentId)
+            ->where('sub_institute_id', $sid)
+            ->where('certification_id', $id)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$document) {
+            return response()->json(['status' => 0, 'message' => 'Document not found'], 404);
+        }
+
+        DB::table(self::EVIDENCE)->where('id', $documentId)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'deleted_certification_document',
+            'Removed document "' . $document->title . '"',
+            'certification',
+            (int) $id,
+            $document->title
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Document deleted successfully']);
+    }
+
+    /* ================================================================== *
+     * Helpers
+     * ================================================================== */
+
+    /** Shared filter pipeline for index() and export(). */
+    private function filteredQuery(Request $request, int $sid)
+    {
+        $today = now()->toDateString();
+
+        $query = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('status', $status);
+        }
+
+        if ($search = $this->activeFilter($request->input('search'))) {
+            // Name / credential id on the row itself, plus the employee behind
+            // it - the placeholder promises "certification or employee".
+            $userIds = DB::table('tbluser')
+                ->where('sub_institute_id', $sid)
+                ->where(function ($q) use ($search) {
+                    $q->where('first_name', 'like', "%{$search}%")
+                        ->orWhere('last_name', 'like', "%{$search}%")
+                        ->orWhere('employee_no', 'like', "%{$search}%")
+                        ->orWhereRaw("CONCAT(COALESCE(first_name,''), ' ', COALESCE(last_name,'')) like ?", ["%{$search}%"]);
+                })
+                ->limit(500)
+                ->pluck('id')->all();
+
+            $query->where(function ($q) use ($search, $userIds) {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('credential_id', 'like', "%{$search}%")
+                    ->orWhere('issuing_body', 'like', "%{$search}%");
+                if ($userIds) {
+                    $q->orWhereIn('user_id', $userIds);
+                }
+            });
+        }
+
+        if ($departmentId = $this->activeFilter($request->input('department_id'))) {
+            $query->where('department_id', $departmentId);
+        }
+        if ($jobrole = $this->activeFilter($request->input('jobrole'))) {
+            $query->where('jobrole', $jobrole);
+        }
+        if ($type = $this->activeFilter($request->input('certification_type'))) {
+            $query->where('certification_type', $type);
+        }
+        if ($issuer = $this->activeFilter($request->input('issuing_body'))) {
+            $query->where('issuing_body', $issuer);
+        }
+        if ($verification = $this->activeFilter($request->input('verification_status'))) {
+            $query->where('verification_status', $verification);
+        }
+        // "My Certifications" - user_id alone is the context actor, so the
+        // employee filter travels under its own key (same as development plans).
+        if ($userFilter = $this->activeFilter($request->input('user_id_filter'))) {
+            $query->where('user_id', $userFilter);
+        }
+        if ($from = $this->activeFilter($request->input('issued_from'))) {
+            $query->where('issued_date', '>=', $from);
+        }
+        if ($to = $this->activeFilter($request->input('issued_to'))) {
+            $query->where('issued_date', '<=', $to);
+        }
+        if ($from = $this->activeFilter($request->input('expiry_from'))) {
+            $query->where('expiry_date', '>=', $from);
+        }
+        if ($to = $this->activeFilter($request->input('expiry_to'))) {
+            $query->where('expiry_date', '<=', $to);
+        }
+
+        // Derived compliance - mirrors complianceState() exactly so the badge,
+        // the filter and the KPI cards can never disagree.
+        if ($compliance = $this->activeFilter($request->input('compliance'))) {
+            $window = now()->addDays(self::EXPIRING_WINDOW_DAYS)->toDateString();
+
+            if ($compliance === 'non_compliant') {
+                $query->where(function ($q) use ($today) {
+                    $q->whereIn('status', ['revoked', 'expired'])
+                        ->orWhere(function ($inner) use ($today) {
+                            $inner->whereNotNull('expiry_date')->where('expiry_date', '<', $today);
+                        });
+                });
+            } elseif ($compliance === 'expiring') {
+                $query->whereNotIn('status', ['revoked', 'expired'])
+                    ->whereNotNull('expiry_date')
+                    ->whereBetween('expiry_date', [$today, $window]);
+            } elseif ($compliance === 'compliant') {
+                $query->whereNotIn('status', ['revoked', 'expired'])
+                    ->where(function ($q) use ($window) {
+                        $q->whereNull('expiry_date')->orWhere('expiry_date', '>', $window);
+                    });
+            }
+        }
+
+        // Expiry window pill / filter.
+        if ($window = $this->activeFilter($request->input('expiry_window'))) {
+            if ($window === 'expired') {
+                $query->where(function ($q) use ($today) {
+                    $q->where('status', 'expired')
+                        ->orWhere(function ($inner) use ($today) {
+                            $inner->whereNotNull('expiry_date')->where('expiry_date', '<', $today);
+                        });
+                });
+            } elseif (is_numeric($window)) {
+                $until = now()->addDays((int) $window)->toDateString();
+                $query->whereNotIn('status', ['revoked', 'expired'])
+                    ->whereNotNull('expiry_date')
+                    ->whereBetween('expiry_date', [$today, $until]);
+            }
+        }
+
+        return $query;
+    }
+
+    private function findCertification($id, int $sid)
+    {
+        return DB::table(self::TABLE)
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+    }
+
+    /**
+     * The single source of truth for the Compliance column, the Compliance
+     * filter and the compliance tab. Evaluated as an ordered ladder.
+     *
+     * @return array{key:string, label:string, reason:string}
+     */
+    private function complianceState($row): array
+    {
+        $expiry = $row->expiry_date ? strtotime((string) $row->expiry_date) : null;
+        $today = strtotime(now()->toDateString());
+
+        if ($row->status === 'revoked') {
+            return ['key' => 'non_compliant', 'label' => 'Non-Compliant', 'reason' => 'Credential has been revoked'];
+        }
+        if ($row->status === 'expired' || ($expiry !== null && $expiry < $today)) {
+            return ['key' => 'non_compliant', 'label' => 'Non-Compliant', 'reason' => 'Credential has expired'];
+        }
+        if ($expiry !== null && $expiry <= strtotime('+' . self::EXPIRING_WINDOW_DAYS . ' days', $today)) {
+            return [
+                'key'    => 'expiring',
+                'label'  => 'Expiring Soon',
+                'reason' => 'Expires within ' . self::EXPIRING_WINDOW_DAYS . ' days',
+            ];
+        }
+
+        return ['key' => 'compliant', 'label' => 'Compliant', 'reason' => 'Credential is valid'];
+    }
+
+    private function daysToExpiry($expiryDate): ?int
+    {
+        if (!$expiryDate) {
+            return null;
+        }
+        $today = strtotime(now()->toDateString());
+
+        return (int) floor((strtotime((string) $expiryDate) - $today) / 86400);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function decorateRows($rows, int $sid): array
+    {
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        $users = $this->userMap($rows->pluck('user_id')->filter()->all());
+
+        $departmentIds = $rows->pluck('department_id')->filter()->unique()->all();
+        $departments = [];
+        if ($departmentIds) {
+            $departments = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->whereIn('department_id', $departmentIds)
+                ->whereNull('deleted_at')
+                ->pluck('department', 'department_id')
+                ->all();
+        }
+
+        return $rows->map(function ($r) use ($users, $departments) {
+            $employee = $r->user_id ? ($users[(int) $r->user_id] ?? null) : null;
+            $state = $this->complianceState($r);
+
+            return [
+                'id'                  => (int) $r->id,
+                'name'                => $r->name,
+                'user_id'             => $r->user_id ? (int) $r->user_id : null,
+                'employee_name'       => $employee['name'] ?? null,
+                'employee_initials'   => $employee['initials'] ?? null,
+                'employee_no'         => $employee['employee_no'] ?? null,
+                'department_id'       => $r->department_id ? (int) $r->department_id : null,
+                'department'          => $r->department_id ? ($departments[$r->department_id] ?? null) : null,
+                'jobrole'             => $r->jobrole,
+                'issuing_body'        => $r->issuing_body,
+                'certification_type'  => $r->certification_type,
+                'credential_id'       => $r->credential_id,
+                'competency_id'       => $r->competency_id ? (int) $r->competency_id : null,
+                'requirement_id'      => $r->requirement_id ? (int) $r->requirement_id : null,
+                'status'              => $r->status,
+                'status_label'        => self::STATUS_LABELS[$r->status] ?? ucfirst((string) $r->status),
+                'compliance'          => $state['label'],
+                'compliance_key'      => $state['key'],
+                'compliance_reason'   => $state['reason'],
+                'verification_status' => $r->verification_status,
+                'issued_date'         => $r->issued_date,
+                'expiry_date'         => $r->expiry_date,
+                'issued_date_label'   => $this->humanDate($r->issued_date),
+                'expiry_date_label'   => $this->humanDate($r->expiry_date),
+                'days_to_expiry'      => $this->daysToExpiry($r->expiry_date),
+                'notes'               => $r->notes,
+                'created_at'          => $r->created_at,
+            ];
+        })->values()->all();
+    }
+
+    /** The Overview panel's employee block. */
+    private function employeeCard(int $userId, int $sid): ?array
+    {
+        $user = DB::table('tbluser')->where('id', $userId)->first();
+        if (!$user) {
+            return null;
+        }
+
+        $first = trim((string) $user->first_name);
+        $last = trim((string) $user->last_name);
+        $name = trim($first . ' ' . $last) ?: ('User ' . $user->id);
+
+        // Same role resolution the rest of the module uses: jobtitle_id first,
+        // then allocated_standards, which is what this tenant actually fills in.
+        $roleId = ($user->jobtitle_id ?? 0) ?: $this->firstNumeric($user->allocated_standards ?? null);
+        $role = $roleId
+            ? DB::table('s_user_jobrole')->where('id', $roleId)->whereNull('deleted_at')->first()
+            : null;
+
+        $departmentId = $user->department_id ?? null;
+        $department = $role->department ?? null;
+        if (!$department && $departmentId) {
+            $department = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)->where('department_id', $departmentId)
+                ->whereNull('deleted_at')->value('department');
+        }
+
+        return [
+            'id'          => (int) $user->id,
+            'name'        => $name,
+            'initials'    => (strtoupper(substr($first ?: $name, 0, 1) . substr($last, 0, 1)) ?: strtoupper(substr($name, 0, 2))),
+            'employee_no' => $user->employee_no ?? null,
+            'email'       => $user->email ?? null,
+            'jobrole'     => $role->jobrole ?? null,
+            'department'  => $department,
+        ];
+    }
+
+    /** Requirements that apply to a given role / department (or org-wide). */
+    private function requirementsFor(int $sid, ?string $jobrole, $departmentId)
+    {
+        return DB::table(self::REQUIREMENTS)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('status', 'active')
+            ->where(function ($q) use ($jobrole, $departmentId) {
+                // Org-wide: scoped to neither a role nor a department.
+                $q->where(function ($inner) {
+                    $inner->where(function ($j) {
+                        $j->whereNull('jobrole')->orWhere('jobrole', '');
+                    })->whereNull('department_id');
+                });
+                if ($jobrole) {
+                    $q->orWhere('jobrole', $jobrole);
+                }
+                if ($departmentId) {
+                    $q->orWhere('department_id', $departmentId);
+                }
+            })
+            ->orderByDesc('is_mandatory')
+            ->orderBy('name')
+            ->get();
+    }
+
+    private function requirementRow($r): array
+    {
+        return [
+            'id'                    => (int) $r->id,
+            'name'                  => $r->name,
+            'certification_type'    => $r->certification_type,
+            'issuing_body'          => $r->issuing_body,
+            'description'           => $r->description,
+            'department_id'         => $r->department_id ? (int) $r->department_id : null,
+            'jobrole'               => $r->jobrole,
+            'is_mandatory'          => (bool) $r->is_mandatory,
+            'validity_months'       => $r->validity_months ? (int) $r->validity_months : null,
+            'renewal_reminder_days' => $r->renewal_reminder_days ? (int) $r->renewal_reminder_days : null,
+            'grace_period_days'     => $r->grace_period_days ? (int) $r->grace_period_days : null,
+            'scope'                 => $r->jobrole ?: ($r->department_id ? 'Department' : 'Organisation-wide'),
+            'status'                => $r->status,
+        ];
+    }
+
+    /** Find the requirement a held credential satisfies, by id or by name. */
+    private function matchRequirement($requirements, ?string $certName, $requirementId)
+    {
+        foreach ($requirements as $requirement) {
+            if ($requirementId && (int) $requirement->id === (int) $requirementId) {
+                return $requirement;
+            }
+        }
+        foreach ($requirements as $requirement) {
+            if ($this->sameName($certName, $requirement->name)) {
+                return $requirement;
+            }
+        }
+
+        return null;
+    }
+
+    private function sameName(?string $a, ?string $b): bool
+    {
+        return $a !== null && $b !== null && strcasecmp(trim($a), trim($b)) === 0;
+    }
+
+    /**
+     * The "Compliant Employees" KPI.
+     *
+     * Compliance is measured against REQUIREMENTS, not against every credential
+     * a person happens to hold: an employee counts as compliant when every
+     * mandatory requirement applying to them (job role, department, or
+     * organisation-wide) is satisfied by a credential that is currently live -
+     * i.e. neither revoked nor past its expiry date.
+     *
+     * A lapsed credential that nobody asked for does NOT make its holder
+     * non-compliant; that is what the Expired KPI counts. Conversely a
+     * mandatory requirement that is unmet, or met only by an expired
+     * credential, does.
+     *
+     * The denominator is every employee who either holds a credential or has an
+     * applicable requirement - people the module has nothing to say about are
+     * counted neither way.
+     *
+     * Pass $onlyUserId to evaluate a single employee.
+     *
+     * @return array{compliant:int, universe:int, percent:int, missing:array}
+     */
+    private function employeeCompliance(int $sid, ?int $onlyUserId = null): array
+    {
+        $requirements = DB::table(self::REQUIREMENTS)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('status', 'active')
+            ->get();
+
+        $certQuery = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereNotNull('user_id');
+
+        if ($onlyUserId) {
+            $certQuery->where('user_id', $onlyUserId);
+        }
+        $certs = $certQuery->get()->groupBy('user_id');
+
+        $employeeQuery = DB::table('tbluser')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        if ($onlyUserId) {
+            $employeeQuery->where('id', $onlyUserId);
+        }
+        $employees = $employeeQuery->limit(2000)
+            ->get(['id', 'jobtitle_id', 'department_id', 'allocated_standards']);
+
+        // Resolve each employee's role once.
+        $roleIds = [];
+        foreach ($employees as $employee) {
+            $roleId = ($employee->jobtitle_id ?? 0) ?: $this->firstNumeric($employee->allocated_standards ?? null);
+            if ($roleId) {
+                $roleIds[$employee->id] = $roleId;
+            }
+        }
+        $roles = $roleIds
+            ? DB::table('s_user_jobrole')->whereIn('id', array_values($roleIds))->whereNull('deleted_at')
+                ->pluck('jobrole', 'id')->all()
+            : [];
+
+        $compliant = 0;
+        $universe = 0;
+        $missing = [];
+
+        foreach ($employees as $employee) {
+            $held = $certs[$employee->id] ?? collect();
+            $jobrole = isset($roleIds[$employee->id]) ? ($roles[$roleIds[$employee->id]] ?? null) : null;
+            $departmentId = $employee->department_id ?? null;
+
+            // A certification row also records the role/department it was filed
+            // against, so fall back to that when tbluser has neither.
+            if (!$jobrole && $held->isNotEmpty()) {
+                $jobrole = $held->first()->jobrole;
+            }
+            if (!$departmentId && $held->isNotEmpty()) {
+                $departmentId = $held->first()->department_id;
+            }
+
+            $applicable = $requirements->filter(function ($requirement) use ($jobrole, $departmentId) {
+                $orgWide = (!$requirement->jobrole || $requirement->jobrole === '') && !$requirement->department_id;
+                if ($orgWide) {
+                    return true;
+                }
+                if ($requirement->jobrole && $jobrole && strcasecmp($requirement->jobrole, $jobrole) === 0) {
+                    return true;
+                }
+
+                return $requirement->department_id && $departmentId
+                    && (int) $requirement->department_id === (int) $departmentId;
+            });
+
+            if ($held->isEmpty() && $applicable->isEmpty()) {
+                continue; // Nothing to judge this employee on.
+            }
+            $universe++;
+
+            $isCompliant = true;
+            $employeeMissing = [];
+
+            foreach ($applicable as $requirement) {
+                if (!$requirement->is_mandatory) {
+                    continue;
+                }
+                $met = false;
+                foreach ($held as $cert) {
+                    $sameRequirement = $cert->requirement_id && (int) $cert->requirement_id === (int) $requirement->id;
+                    if (($sameRequirement || $this->sameName($cert->name, $requirement->name))
+                        && $this->complianceState($cert)['key'] !== 'non_compliant') {
+                        $met = true;
+                        break;
+                    }
+                }
+                if (!$met) {
+                    $isCompliant = false;
+                    $employeeMissing[] = $requirement->name;
+                }
+            }
+
+            if ($isCompliant) {
+                $compliant++;
+            } elseif ($employeeMissing) {
+                $missing = array_values(array_unique(array_merge($missing, $employeeMissing)));
+            }
+        }
+
+        return [
+            'compliant' => $compliant,
+            'universe'  => $universe,
+            'percent'   => $universe ? (int) round(($compliant / $universe) * 100) : 0,
+            'missing'   => $missing,
+        ];
+    }
+
+    /** @return array<int, array{name:string, initials:string, employee_no:?string}> */
+    private function userMap(array $ids): array
+    {
+        $ids = array_values(array_filter(array_unique($ids)));
+        if (!$ids) {
+            return [];
+        }
+
+        return DB::table('tbluser')
+            ->whereIn('id', $ids)
+            ->get(['id', 'first_name', 'last_name', 'employee_no'])
+            ->mapWithKeys(function ($u) {
+                $first = trim((string) $u->first_name);
+                $last = trim((string) $u->last_name);
+                $name = trim($first . ' ' . $last) ?: ('User ' . $u->id);
+                $initials = strtoupper(substr($first ?: $name, 0, 1) . substr($last, 0, 1));
+
+                return [(int) $u->id => [
+                    'name'        => $name,
+                    'initials'    => $initials ?: strtoupper(substr($name, 0, 2)),
+                    'employee_no' => $u->employee_no,
+                ]];
+            })
+            ->all();
+    }
+
+    private function updateAction(Request $request): string
+    {
+        if ($request->has('verification_status')) {
+            return 'verified_certification';
+        }
+        if ($request->input('status') === 'revoked') {
+            return 'revoked_certification';
+        }
+        if ($request->has('status')) {
+            return 'updated_certification_status';
+        }
+
+        return 'updated_certification';
+    }
+
+    private function updateDescription(Request $request, ?string $name): string
+    {
+        $name = $name ?: 'certification';
+
+        if ($request->has('verification_status')) {
+            return ucfirst((string) $request->input('verification_status')) . ' certification "' . $name . '"';
+        }
+        if ($request->input('status') === 'revoked') {
+            return 'Revoked certification "' . $name . '"';
+        }
+        if ($request->has('status')) {
+            return 'Set certification "' . $name . '" to ' . (self::STATUS_LABELS[$request->input('status')] ?? $request->input('status'));
+        }
+
+        return 'Updated certification "' . $name . '"';
+    }
+
+    private function fileUrl(?string $path): ?string
+    {
+        if (!$path) {
+            return null;
+        }
+
+        try {
+            return Storage::disk('digitalocean')->url($path);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function firstNumeric($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        foreach (array_map('trim', explode(',', (string) $value)) as $part) {
+            if (is_numeric($part)) {
+                return (int) $part;
+            }
+        }
+
+        return null;
+    }
+
+    private function humanDate($value): ?string
+    {
+        return $value ? date('d M Y', strtotime((string) $value)) : null;
+    }
+}

--- a/app/Http/Controllers/Api/Competency/CertificationRequirementController.php
+++ b/app/Http/Controllers/Api/Competency/CertificationRequirementController.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Certification requirements (s_competency_certification_requirements) - the
+ * policy layer behind the Certification & Compliance Center's "Add
+ * Certification Requirement" action and its Requirements tab: which credential
+ * a job role / department / the whole organisation is expected to hold.
+ *
+ * Follows the same conventions as the sibling competency controllers: Sanctum
+ * token in the query string, tenant scoping by sub_institute_id, soft deletes,
+ * a {status,message,data[,pagination]} envelope and an entry on the shared
+ * competency activity feed.
+ */
+class CertificationRequirementController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    private const TABLE = 's_competency_certification_requirements';
+    private const CERTIFICATIONS = 's_competency_certifications';
+
+    private const SORTABLE = [
+        'name'         => 'name',
+        'is_mandatory' => 'is_mandatory',
+        'status'       => 'status',
+        'created_at'   => 'created_at',
+    ];
+
+    /**
+     * GET /competency/certification-requirements
+     *
+     * Filters: search, status, department_id, jobrole, certification_type,
+     *          is_mandatory
+     */
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 50), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('issuing_body', 'like', "%{$search}%")
+                    ->orWhere('jobrole', 'like', "%{$search}%");
+            });
+        }
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('status', $status);
+        }
+        if ($departmentId = $this->activeFilter($request->input('department_id'))) {
+            $query->where('department_id', $departmentId);
+        }
+        if ($jobrole = $this->activeFilter($request->input('jobrole'))) {
+            $query->where('jobrole', $jobrole);
+        }
+        if ($type = $this->activeFilter($request->input('certification_type'))) {
+            $query->where('certification_type', $type);
+        }
+        if (($mandatory = $request->input('is_mandatory')) !== null && $mandatory !== '' && $mandatory !== 'all') {
+            $query->where('is_mandatory', filter_var($mandatory, FILTER_VALIDATE_BOOLEAN) ? 1 : 0);
+        }
+
+        $total = (clone $query)->count();
+
+        $sortKey = (string) $request->input('sort', 'name');
+        $column = self::SORTABLE[$sortKey] ?? 'name';
+        $direction = strtolower((string) $request->input('direction', 'asc')) === 'desc' ? 'desc' : 'asc';
+
+        $rows = $query->orderBy($column, $direction)->orderByDesc('id')
+            ->forPage($page, $perPage)->get();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Certification requirements fetched successfully',
+            'data'       => $this->decorateRows($rows, $sid),
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), $this->rules());
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table(self::TABLE)->insertGetId([
+            'sub_institute_id'      => $context['sub_institute_id'],
+            'name'                  => $request->input('name'),
+            'certification_type'    => $request->input('certification_type'),
+            'issuing_body'          => $request->input('issuing_body'),
+            'description'           => $request->input('description'),
+            'department_id'         => $request->input('department_id'),
+            'jobrole'               => $this->activeFilter($request->input('jobrole')),
+            'competency_id'         => $request->input('competency_id'),
+            'is_mandatory'          => $request->boolean('is_mandatory', true) ? 1 : 0,
+            'validity_months'       => $request->input('validity_months'),
+            'renewal_reminder_days' => $request->input('renewal_reminder_days', 60),
+            'grace_period_days'     => $request->input('grace_period_days'),
+            'status'                => $request->input('status', 'active'),
+            'created_by'            => $context['user_id'],
+            'updated_by'            => $context['user_id'],
+            'created_at'            => now(),
+            'updated_at'            => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'added_certification_requirement',
+            'Added certification requirement "' . $request->input('name') . '"',
+            'certification_requirement',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification requirement created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $existing = $this->find($id, $sid);
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Certification requirement not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), $this->rules(true));
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = ['updated_by' => $context['user_id'], 'updated_at' => now()];
+
+        foreach (['name', 'certification_type', 'issuing_body', 'description', 'department_id',
+            'competency_id', 'validity_months', 'renewal_reminder_days', 'grace_period_days', 'status'] as $field) {
+            if ($request->has($field)) {
+                $update[$field] = $request->input($field);
+            }
+        }
+        if ($request->has('jobrole')) {
+            $update['jobrole'] = $this->activeFilter($request->input('jobrole'));
+        }
+        if ($request->has('is_mandatory')) {
+            $update['is_mandatory'] = $request->boolean('is_mandatory') ? 1 : 0;
+        }
+
+        DB::table(self::TABLE)->where('id', $id)->update($update);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_certification_requirement',
+            'Updated certification requirement "' . ($request->input('name') ?: $existing->name) . '"',
+            'certification_requirement',
+            (int) $id,
+            $request->input('name') ?: $existing->name
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Certification requirement updated successfully',
+            'data'    => ['id' => (int) $id],
+        ]);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $existing = $this->find($id, $sid);
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Certification requirement not found'], 404);
+        }
+
+        DB::table(self::TABLE)->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        // Held credentials keep their history - only the policy link is cleared.
+        DB::table(self::CERTIFICATIONS)
+            ->where('sub_institute_id', $sid)
+            ->where('requirement_id', $id)
+            ->update(['requirement_id' => null, 'updated_at' => now()]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'deleted_certification_requirement',
+            'Deleted certification requirement "' . $existing->name . '"',
+            'certification_requirement',
+            (int) $id,
+            $existing->name
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Certification requirement deleted successfully']);
+    }
+
+    /* ------------------------------------------------------------------ */
+
+    private function rules(bool $partial = false): array
+    {
+        $required = $partial ? 'sometimes|required' : 'required';
+
+        return [
+            'name'                  => $required . '|string|max:191',
+            'certification_type'    => 'nullable|string|max:100',
+            'issuing_body'          => 'nullable|string|max:191',
+            'description'           => 'nullable|string',
+            'department_id'         => 'nullable|integer',
+            'jobrole'               => 'nullable|string|max:191',
+            'competency_id'         => 'nullable|integer',
+            'is_mandatory'          => 'nullable|boolean',
+            'validity_months'       => 'nullable|integer|min:1|max:600',
+            'renewal_reminder_days' => 'nullable|integer|min:0|max:365',
+            'grace_period_days'     => 'nullable|integer|min:0|max:365',
+            'status'                => 'nullable|in:active,archived',
+        ];
+    }
+
+    private function find($id, int $sid)
+    {
+        return DB::table(self::TABLE)
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+    }
+
+    /**
+     * Adds the department name plus live coverage - how many people already
+     * hold the credential this requirement asks for.
+     */
+    private function decorateRows($rows, int $sid): array
+    {
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        $departmentIds = $rows->pluck('department_id')->filter()->unique()->all();
+        $departments = [];
+        if ($departmentIds) {
+            $departments = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->whereIn('department_id', $departmentIds)
+                ->whereNull('deleted_at')
+                ->pluck('department', 'department_id')
+                ->all();
+        }
+
+        // One grouped query instead of a count per requirement.
+        $names = $rows->pluck('name')->unique()->all();
+        $heldByName = DB::table(self::CERTIFICATIONS)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereIn('name', $names)
+            ->whereNotIn('status', ['revoked', 'expired'])
+            ->select('name', DB::raw('COUNT(DISTINCT user_id) as holders'))
+            ->groupBy('name')
+            ->pluck('holders', 'name')
+            ->all();
+
+        return $rows->map(function ($r) use ($departments, $heldByName) {
+            return [
+                'id'                    => (int) $r->id,
+                'name'                  => $r->name,
+                'certification_type'    => $r->certification_type,
+                'issuing_body'          => $r->issuing_body,
+                'description'           => $r->description,
+                'department_id'         => $r->department_id ? (int) $r->department_id : null,
+                'department'            => $r->department_id ? ($departments[$r->department_id] ?? null) : null,
+                'jobrole'               => $r->jobrole,
+                'competency_id'         => $r->competency_id ? (int) $r->competency_id : null,
+                'is_mandatory'          => (bool) $r->is_mandatory,
+                'validity_months'       => $r->validity_months ? (int) $r->validity_months : null,
+                'renewal_reminder_days' => $r->renewal_reminder_days ? (int) $r->renewal_reminder_days : null,
+                'grace_period_days'     => $r->grace_period_days ? (int) $r->grace_period_days : null,
+                'status'                => $r->status,
+                'scope'                 => $r->jobrole
+                    ?: ($r->department_id ? ($departments[$r->department_id] ?? 'Department') : 'Organisation-wide'),
+                'holders'               => (int) ($heldByName[$r->name] ?? 0),
+                'created_at'            => $r->created_at,
+            ];
+        })->values()->all();
+    }
+}

--- a/app/Http/Controllers/Api/Competency/CommandCenterController.php
+++ b/app/Http/Controllers/Api/Competency/CommandCenterController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use App\Services\Competency\CommandCenterService;
+use Illuminate\Http\Request;
+
+/**
+ * Competency Command Center dashboard.
+ *
+ * GET /api/competency/command-center          -> the full dashboard payload
+ * GET /api/competency/command-center/filters  -> options for the five filters
+ *
+ * Token authenticated + tenant scoped via ResolvesCompetencyContext.
+ */
+class CommandCenterController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    public function __construct(private CommandCenterService $service) {}
+
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $filters = $this->competencyFilters($request);
+
+        $data = $this->service->dashboard(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            $filters
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency command center fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    public function filters(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency filters fetched successfully',
+            'data'    => $this->service->filterOptions($context['sub_institute_id']),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Competency/CompetencyController.php
+++ b/app/Http/Controllers/Api/Competency/CompetencyController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Competencies CRUD.
+ *
+ * In this ERP a "competency" is an approved skill, so this operates on the
+ * existing s_users_skills catalog (no separate competency table). Backs the
+ * "Create Competency" quick action on the Command Center and the Competency
+ * Library screen. Competency status maps onto the skill's approve_status
+ * (published -> Approved, otherwise Pending).
+ */
+class CompetencyController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $perPage = min(max((int) $request->input('per_page', 15), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table('s_users_skills')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            // 'published' competencies == approved skills.
+            $query->where('approve_status', $status === 'published' ? 'Approved' : 'Pending');
+        }
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('title', 'like', "%{$search}%");
+        }
+
+        $total = (clone $query)->count();
+        $rows = $query->orderByDesc('id')
+            ->forPage($page, $perPage)
+            ->get([
+                'id',
+                'title as name',
+                'description',
+                'category',
+                'proficiency_level',
+                'department_id',
+                'approve_status',
+                'status',
+                'created_at',
+            ]);
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Competencies fetched successfully',
+            'data'       => $rows,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'          => 'required|string|max:191',
+            'description'   => 'nullable|string',
+            'category'      => 'nullable|string|max:191',
+            'status'        => 'nullable|in:draft,published,archived',
+            'department_id' => 'nullable|integer',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table('s_users_skills')->insertGetId([
+            'sub_institute_id' => $context['sub_institute_id'],
+            'title'            => $request->input('name'),
+            'description'      => $request->input('description'),
+            'category'         => $request->input('category'),
+            'department_id'    => $request->input('department_id'),
+            'status'           => 'Active',
+            'approve_status'   => $request->input('status') === 'published' ? 'Approved' : 'Pending',
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'created_competency',
+            'Created competency "' . $request->input('name') . '"',
+            'competency',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $existing = DB::table('s_users_skills')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        DB::table('s_users_skills')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_competency',
+            'Deleted competency "' . $existing->title . '"',
+            'competency',
+            (int) $id,
+            $existing->title
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Competency deleted successfully']);
+    }
+}

--- a/app/Http/Controllers/Api/Competency/Concerns/ManagesCompetencySettings.php
+++ b/app/Http/Controllers/Api/Competency/Concerns/ManagesCompetencySettings.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency\Concerns;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Shared read/write for s_competency_settings, the module's key/value settings
+ * store. Used by the Framework Studio's "Weighting Configuration" panel and the
+ * Assessment Workspace's "View Configuration" panel.
+ *
+ * Values are stored as text and cast back on read against a defaults map, so a
+ * setting that has never been saved returns its default rather than null and a
+ * caller never has to guard for a missing row.
+ */
+trait ManagesCompetencySettings
+{
+    private const SETTINGS_TABLE = 's_competency_settings';
+
+    /**
+     * Read one scope's settings, merged over $defaults.
+     *
+     * @param  array<string, mixed> $defaults
+     * @return array<string, mixed>
+     */
+    protected function competencySettings(int $sid, string $scope, array $defaults, ?int $scopeId = null): array
+    {
+        $query = DB::table(self::SETTINGS_TABLE)
+            ->where('sub_institute_id', $sid)
+            ->where('scope', $scope);
+
+        $scopeId === null ? $query->whereNull('scope_id') : $query->where('scope_id', $scopeId);
+
+        $stored = $query->pluck('value', 'key');
+
+        $settings = [];
+        foreach ($defaults as $key => $default) {
+            $settings[$key] = $stored->has($key)
+                ? $this->castSetting($stored[$key], $default)
+                : $default;
+        }
+
+        return $settings;
+    }
+
+    /**
+     * Upsert one scope's settings. Only keys present in $defaults are written,
+     * so an unexpected field in the request body cannot create a stray setting.
+     *
+     * @param  array<string, mixed> $values   incoming (already validated)
+     * @param  array<string, mixed> $defaults the allowed key set + types
+     * @return array<string, mixed> the settings as they now stand
+     */
+    protected function saveCompetencySettings(
+        int $sid,
+        string $scope,
+        array $values,
+        array $defaults,
+        ?int $userId = null,
+        ?int $scopeId = null
+    ): array {
+        foreach ($defaults as $key => $default) {
+            if (!array_key_exists($key, $values)) {
+                continue;
+            }
+
+            $value = $values[$key];
+
+            if (is_bool($default)) {
+                $value = filter_var($value, FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+            } elseif (is_array($default)) {
+                $value = json_encode(array_values((array) $value));
+            } else {
+                $value = (string) $value;
+            }
+
+            DB::table(self::SETTINGS_TABLE)->updateOrInsert(
+                [
+                    'sub_institute_id' => $sid,
+                    'scope'            => $scope,
+                    'scope_id'         => $scopeId,
+                    'key'              => $key,
+                ],
+                [
+                    'value'      => $value,
+                    'updated_by' => $userId,
+                    'created_by' => DB::raw('COALESCE(created_by, ' . ($userId ?: 'NULL') . ')'),
+                    'updated_at' => now(),
+                    'created_at' => DB::raw('COALESCE(created_at, NOW())'),
+                ]
+            );
+        }
+
+        return $this->competencySettings($sid, $scope, $defaults, $scopeId);
+    }
+
+    /** Cast a stored string back to the type implied by its default. */
+    private function castSetting($stored, $default)
+    {
+        if (is_bool($default)) {
+            return filter_var($stored, FILTER_VALIDATE_BOOLEAN);
+        }
+        if (is_int($default)) {
+            return (int) $stored;
+        }
+        if (is_float($default)) {
+            return (float) $stored;
+        }
+        if (is_array($default)) {
+            $decoded = json_decode((string) $stored, true);
+            return is_array($decoded) ? $decoded : $default;
+        }
+
+        return (string) $stored;
+    }
+}

--- a/app/Http/Controllers/Api/Competency/Concerns/ResolvesCompetencyContext.php
+++ b/app/Http/Controllers/Api/Competency/Concerns/ResolvesCompetencyContext.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency\Concerns;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Shared request context resolution for the Competency Management API.
+ *
+ * Mirrors ResolvesLeaveContext: every endpoint under /api/competency/* that
+ * this trait guards is token authenticated (Sanctum personal access token
+ * passed as `token`) and tenant scoped by sub_institute_id. Competency data is
+ * not fiscal-year scoped, so there is no leave-year handling here.
+ */
+trait ResolvesCompetencyContext
+{
+    /**
+     * @return array{sub_institute_id:int, user_id:int|null}|\Illuminate\Http\JsonResponse
+     */
+    protected function competencyContext(Request $request)
+    {
+        $token = $request->input('token');
+
+        if (!$token) {
+            return response()->json(['status' => 0, 'message' => 'Token not provided'], 401);
+        }
+
+        if (!PersonalAccessToken::findToken($token)) {
+            return response()->json(['status' => 0, 'message' => 'Invalid token'], 401);
+        }
+
+        $subInstituteId = $request->input('sub_institute_id') ?? $request->header('sub_institute_id');
+
+        if (!$subInstituteId || !is_numeric($subInstituteId)) {
+            return response()->json(['status' => 0, 'message' => 'sub_institute_id is required'], 400);
+        }
+
+        return [
+            'sub_institute_id' => (int) $subInstituteId,
+            'user_id'          => is_numeric($request->input('user_id')) ? (int) $request->input('user_id') : null,
+        ];
+    }
+
+    /**
+     * The five command-center filter dimensions, normalised. Empty / 'all' / '0'
+     * collapse to null so callers can skip them. Department and Job Role map to
+     * columns that exist on the domain tables; Business Unit (industries),
+     * Location and Job Family (jobrole_category) live on s_user_jobrole and are
+     * resolved to a set of matching jobroles by the service.
+     *
+     * @return array{department_id:?string, jobrole:?string, location:?string, business_unit:?string, job_family:?string}
+     */
+    protected function competencyFilters(Request $request): array
+    {
+        return [
+            'department_id' => $this->activeFilter($request->input('department_id')),
+            'jobrole'       => $this->activeFilter($request->input('jobrole')),
+            'location'      => $this->activeFilter($request->input('location')),
+            'business_unit' => $this->activeFilter($request->input('business_unit')),
+            'job_family'    => $this->activeFilter($request->input('job_family')),
+        ];
+    }
+
+    /** Treat 'all', '0' and empty string as "no filter". */
+    protected function activeFilter($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            $value = array_values(array_filter($value, fn ($item) => $item !== null && $item !== '' && $item !== '0' && $item !== 'all'));
+            return empty($value) ? null : implode(',', $value);
+        }
+
+        $value = trim((string) $value);
+
+        return ($value === '' || $value === '0' || strtolower($value) === 'all') ? null : $value;
+    }
+
+    /**
+     * Append a row to the competency activity feed. Resolves the actor's display
+     * name from tbluser so the Recent Activity feed reads naturally.
+     *
+     * $subjectName and $changes are optional trailing parameters added for the
+     * Audit & Activity Center: the first fills its "Record Name" column, the
+     * second its "Change Summary" card / "Version History" tab. Both default to
+     * null so every pre-existing call site keeps working unchanged.
+     *
+     * @param array<int, array{field:string, label:string, old:mixed, new:mixed}>|null $changes
+     */
+    protected function logCompetencyActivity(
+        int $subInstituteId,
+        ?int $userId,
+        string $action,
+        string $description,
+        ?string $subjectType = null,
+        ?int $subjectId = null,
+        ?string $subjectName = null,
+        ?array $changes = null
+    ): void {
+        $actorName = null;
+
+        if ($userId) {
+            $user = DB::table('tbluser')->where('id', $userId)->first();
+            if ($user) {
+                $actorName = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));
+                $actorName = $actorName !== '' ? $actorName : ($user->user_name ?? null);
+            }
+        }
+
+        DB::table('s_competency_activity_log')->insert([
+            'sub_institute_id' => $subInstituteId,
+            'user_id'          => $userId,
+            'actor_name'       => $actorName,
+            'action'           => $action,
+            'description'      => $description,
+            'subject_type'     => $subjectType,
+            'subject_id'       => $subjectId,
+            'subject_name'     => $subjectName !== null ? mb_substr($subjectName, 0, 191) : null,
+            'changes'          => ($changes !== null && $changes !== []) ? json_encode(array_values($changes)) : null,
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+    }
+
+    /**
+     * Build the field-level diff the audit centre renders as "Change Summary".
+     *
+     * $before is the row as it stood (object or array), $after the validated
+     * update payload, $labels the human column names to show. Only columns that
+     * are present in $after AND actually differ are returned, so an edit that
+     * touched one field does not report the whole record as changed.
+     *
+     * @param  object|array<string, mixed>   $before
+     * @param  array<string, mixed>          $after
+     * @param  array<string, string>         $labels  column => display label
+     * @return array<int, array{field:string, label:string, old:mixed, new:mixed}>
+     */
+    protected function diffChanges($before, array $after, array $labels): array
+    {
+        $before = is_object($before) ? (array) $before : $before;
+        $changes = [];
+
+        foreach ($after as $column => $newValue) {
+            if (!array_key_exists($column, $labels)) {
+                continue;
+            }
+
+            $oldValue = $before[$column] ?? null;
+
+            // Loose-but-safe comparison: everything reaches the API as a string,
+            // so 3 and '3' must not read as a change.
+            if ((string) ($oldValue ?? '') === (string) ($newValue ?? '')) {
+                continue;
+            }
+
+            $changes[] = [
+                'field' => $column,
+                'label' => $labels[$column],
+                'old'   => $oldValue,
+                'new'   => $newValue,
+            ];
+        }
+
+        return $changes;
+    }
+}

--- a/app/Http/Controllers/Api/Competency/DevelopmentPlanController.php
+++ b/app/Http/Controllers/Api/Competency/DevelopmentPlanController.php
@@ -1,0 +1,1152 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Development plans (s_competency_development_plans) for the Development &
+ * Career Path Workspace.
+ *
+ * index/store/destroy already backed the Command Center's "Create Development
+ * Plan" quick action; the workspace additionally needs plan metrics, a single
+ * plan's detail, edit, the competency gaps behind the plan, its action items
+ * and its history. All of that is additive - index() keeps the same route and
+ * the same {status,message,data,pagination} envelope and only widens the row
+ * shape, so existing consumers keep reading the fields they already read.
+ */
+class DevelopmentPlanController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    private const TABLE = 's_competency_development_plans';
+
+    /** Raw DB status -> the label the workspace renders. */
+    private const STATUS_LABELS = [
+        'active'    => 'In Progress',
+        'completed' => 'Completed',
+        'overdue'   => 'Overdue',
+        'on_hold'   => 'On Hold',
+    ];
+
+    private const SORTABLE = [
+        'title'      => 'title',
+        'status'     => 'status',
+        'progress'   => 'progress',
+        'due_date'   => 'due_date',
+        'created_at' => 'created_at',
+    ];
+
+    /**
+     * Columns worth reporting in the Audit Center's Change Summary, with the
+     * label that card shows. Bookkeeping columns (updated_by/_at, completed_at)
+     * are left out: they move on every edit and would bury the real change.
+     */
+    private const CHANGE_LABELS = [
+        'title'           => 'Plan Title',
+        'objective'       => 'Objective',
+        'focus_areas'     => 'Focus Areas',
+        'user_id'         => 'Employee',
+        'competency_id'   => 'Linked Competency',
+        'framework_id'    => 'Framework',
+        'career_path_id'  => 'Career Path',
+        'department_id'   => 'Department',
+        'jobrole'         => 'Job Role',
+        'status'          => 'Status',
+        'progress'        => 'Progress',
+        'start_date'      => 'Start Date',
+        'due_date'        => 'Due Date',
+        'approver_id'     => 'Approver',
+        'approval_status' => 'Approval Status',
+    ];
+
+    /* ================================================================== *
+     * List
+     * ================================================================== */
+
+    /**
+     * GET /competency/development-plans
+     *
+     * Filters: status, search, department_id, approver_id (plan owner), user_id,
+     *          jobrole, career_path_id
+     * Sort:    sort=title|status|progress|due_date|created_at, direction=asc|desc
+     */
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 15), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('status', $status);
+        }
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('title', 'like', "%{$search}%");
+        }
+        if ($departmentId = $this->activeFilter($request->input('department_id'))) {
+            $query->where('department_id', $departmentId);
+        }
+        if ($approverId = $this->activeFilter($request->input('approver_id'))) {
+            $query->where('approver_id', $approverId);
+        }
+        if ($userId = $this->activeFilter($request->input('user_id_filter'))) {
+            $query->where('user_id', $userId);
+        }
+        if ($jobrole = $this->activeFilter($request->input('jobrole'))) {
+            $query->where('jobrole', $jobrole);
+        }
+        if ($pathId = $this->activeFilter($request->input('career_path_id'))) {
+            $query->where('career_path_id', $pathId);
+        }
+        // Command Center drilldown: "Pending My Approvals".
+        if ($this->activeFilter($request->input('pending_approval'))) {
+            $query->where('approval_status', 'pending_approval');
+        }
+
+        $total = (clone $query)->count();
+
+        $sortKey = (string) $request->input('sort', 'created_at');
+        $column = self::SORTABLE[$sortKey] ?? 'id';
+        $direction = strtolower((string) $request->input('direction', 'desc')) === 'asc' ? 'asc' : 'desc';
+
+        $rows = $query->orderBy($column, $direction)->orderByDesc('id')
+            ->forPage($page, $perPage)->get();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Development plans fetched successfully',
+            'data'       => $this->decorateRows($rows, $sid),
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/development-plans/metrics
+     *
+     * The workspace's five KPI cards. "vs last month" deltas compare the count
+     * created (or, for completed, finished) in the current calendar month with
+     * the previous one.
+     */
+    public function metrics(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $base = fn () => DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        $monthStart = now()->startOfMonth();
+        $prevStart = now()->subMonthNoOverflow()->startOfMonth();
+
+        $createdDelta = function ($table, $column, $extra = null) use ($sid, $monthStart, $prevStart) {
+            $scope = function () use ($table, $sid, $extra) {
+                $q = DB::table($table)->where('sub_institute_id', $sid)->whereNull('deleted_at');
+                if ($extra) {
+                    $extra($q);
+                }
+                return $q;
+            };
+            $current = $scope()->where($column, '>=', $monthStart)->count();
+            $previous = $scope()->where($column, '>=', $prevStart)->where($column, '<', $monthStart)->count();
+            return $current - $previous;
+        };
+
+        // 1. Active development plans
+        $active = (clone $base())->where('status', 'active')->count();
+
+        // 2. In progress = started but not finished; the ring is their mean progress.
+        $inProgressQuery = (clone $base())->where('status', 'active')
+            ->where('progress', '>', 0)->where('progress', '<', 100);
+        $inProgress = (clone $inProgressQuery)->count();
+        $avgProgress = (float) ((clone $inProgressQuery)->avg('progress') ?? 0);
+
+        // 3. Completed
+        $completed = (clone $base())->where('status', 'completed')->count();
+        $completedCurrent = (clone $base())->where('status', 'completed')
+            ->whereRaw('COALESCE(completed_at, updated_at) >= ?', [$monthStart])->count();
+        $completedPrevious = (clone $base())->where('status', 'completed')
+            ->whereRaw('COALESCE(completed_at, updated_at) >= ?', [$prevStart])
+            ->whereRaw('COALESCE(completed_at, updated_at) < ?', [$monthStart])->count();
+
+        // 4. Career paths
+        $careerPaths = DB::table('s_competency_career_paths')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->where('status', '!=', 'archived')->count();
+
+        // 5. Learning assigned by this module (source='competency' keeps the
+        //    LMS module's own assignments out of the competency count).
+        $learningQuery = fn () => DB::table('lms_assignments')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->where('source', 'competency');
+        $learning = $learningQuery()->count();
+        $learningCurrent = $learningQuery()->where('created_at', '>=', $monthStart)->count();
+        $learningPrevious = $learningQuery()
+            ->where('created_at', '>=', $prevStart)->where('created_at', '<', $monthStart)->count();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Development plan metrics fetched successfully',
+            'data'    => [
+                'active_plans'          => $active,
+                'active_plans_delta'    => $createdDelta(self::TABLE, 'created_at', fn ($q) => $q->where('status', 'active')),
+                'in_progress'           => $inProgress,
+                'in_progress_percent'   => (int) round($avgProgress),
+                'completed'             => $completed,
+                'completed_delta'       => $completedCurrent - $completedPrevious,
+                'career_paths'          => $careerPaths,
+                'career_paths_delta'    => $createdDelta('s_competency_career_paths', 'created_at'),
+                'learning_assigned'     => $learning,
+                'learning_delta'        => $learningCurrent - $learningPrevious,
+                'total_plans'           => (clone $base())->count(),
+                'overdue'               => (clone $base())->where('status', 'overdue')->count(),
+                'on_hold'               => (clone $base())->where('status', 'on_hold')->count(),
+                'pending_approval'      => (clone $base())->where('approval_status', 'pending_approval')->count(),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /competency/development-plans/owners
+     *
+     * The "Plan Owner: All" dropdown - only users who actually own a plan in
+     * this tenant, so the filter can never produce an empty result set.
+     */
+    public function owners(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $ids = DB::table(self::TABLE)
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->whereNotNull('approver_id')->where('approver_id', '!=', 0)
+            ->distinct()->pluck('approver_id')->all();
+
+        $users = $this->userMap($ids);
+
+        $data = [];
+        foreach ($ids as $id) {
+            $user = $users[$id] ?? null;
+            $data[] = [
+                'value' => (string) $id,
+                'label' => $user['name'] ?? ('User ' . $id),
+            ];
+        }
+        usort($data, fn ($a, $b) => strcasecmp($a['label'], $b['label']));
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Plan owners fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /**
+     * GET /competency/employee-options
+     *
+     * Employee picker for "Create Development Plan" and "Assign Learning".
+     * Their current job role is resolved the same way the rest of the module
+     * does it - jobtitle_id first, then allocated_standards, which is what this
+     * tenant actually populates.
+     */
+    public function employees(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $query = DB::table('tbluser')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where(function ($q) use ($search) {
+                $q->where('first_name', 'like', "%{$search}%")
+                    ->orWhere('last_name', 'like', "%{$search}%")
+                    ->orWhere('employee_no', 'like', "%{$search}%");
+            });
+        }
+
+        $users = $query->orderBy('first_name')->limit(500)
+            ->get(['id', 'first_name', 'last_name', 'employee_no', 'jobtitle_id', 'department_id', 'allocated_standards']);
+
+        $roleIds = [];
+        foreach ($users as $u) {
+            $roleId = $u->jobtitle_id ?: $this->firstNumeric($u->allocated_standards);
+            if ($roleId) {
+                $roleIds[$u->id] = $roleId;
+            }
+        }
+
+        $roles = $roleIds
+            ? DB::table('s_user_jobrole')->whereIn('id', array_values($roleIds))->whereNull('deleted_at')
+                ->pluck('jobrole', 'id')->all()
+            : [];
+
+        $data = $users->map(function ($u) use ($roleIds, $roles) {
+            $first = trim((string) $u->first_name);
+            $last = trim((string) $u->last_name);
+            $name = trim($first . ' ' . $last) ?: ('User ' . $u->id);
+            $roleId = $roleIds[$u->id] ?? null;
+
+            return [
+                'id'            => (int) $u->id,
+                'name'          => $name,
+                'initials'      => strtoupper(substr($first ?: $name, 0, 1) . substr($last, 0, 1)) ?: strtoupper(substr($name, 0, 2)),
+                'employee_no'   => $u->employee_no,
+                'jobrole'       => $roleId ? ($roles[$roleId] ?? null) : null,
+                'jobrole_id'    => $roleId ? (int) $roleId : null,
+                'department_id' => $u->department_id ? (int) $u->department_id : null,
+            ];
+        })->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Employees fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /* ================================================================== *
+     * Single plan
+     * ================================================================== */
+
+    /** GET /competency/development-plans/{id} */
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $data = $this->decorateRows(collect([$plan]), $sid)[0];
+
+        // Next milestone = earliest still-open action.
+        $next = DB::table('s_competency_plan_actions')
+            ->where('plan_id', $plan->id)->whereNull('deleted_at')
+            ->whereIn('status', ['pending', 'in_progress'])
+            ->orderByRaw('due_date IS NULL, due_date asc')
+            ->orderBy('sequence')->first();
+
+        $data['objective'] = $plan->objective;
+        $data['focus_areas'] = $this->splitList($plan->focus_areas);
+        $data['career_path'] = $plan->career_path_id
+            ? DB::table('s_competency_career_paths')
+                ->where('id', $plan->career_path_id)->whereNull('deleted_at')
+                ->select('id', 'name', 'status')->first()
+            : null;
+        $data['next_milestone'] = $next ? [
+            'id'       => (int) $next->id,
+            'title'    => $next->title,
+            'status'   => $next->status,
+            'due_date' => $this->humanDate($next->due_date),
+        ] : null;
+        $data['action_counts'] = [
+            'total'     => DB::table('s_competency_plan_actions')->where('plan_id', $plan->id)->whereNull('deleted_at')->count(),
+            'completed' => DB::table('s_competency_plan_actions')->where('plan_id', $plan->id)->whereNull('deleted_at')->where('status', 'completed')->count(),
+        ];
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Development plan fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), $this->planRules(true));
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table(self::TABLE)->insertGetId([
+            'sub_institute_id' => $context['sub_institute_id'],
+            'title'            => $request->input('title'),
+            'objective'        => $request->input('objective'),
+            'focus_areas'      => $this->joinList($request->input('focus_areas')),
+            'user_id'          => $request->input('user_id_target') ?: $request->input('user_id'),
+            'competency_id'    => $request->input('competency_id'),
+            'framework_id'     => $request->input('framework_id'),
+            'career_path_id'   => $request->input('career_path_id'),
+            'department_id'    => $request->input('department_id'),
+            'jobrole'          => $request->input('jobrole'),
+            'status'           => $request->input('status', 'active'),
+            'progress'         => (int) $request->input('progress', 0),
+            'start_date'       => $request->input('start_date'),
+            'due_date'         => $request->input('due_date'),
+            'approver_id'      => $request->input('approver_id'),
+            'approval_status'  => $request->input('approver_id') ? 'pending_approval' : null,
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'created_development_plan',
+            'Created development plan "' . $request->input('title') . '"',
+            'development_plan',
+            $id,
+            $request->input('title')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Development plan created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    /** PUT /competency/development-plans/{id} */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), $this->planRules(false));
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = ['updated_by' => $context['user_id'], 'updated_at' => now()];
+
+        foreach (['title', 'objective', 'competency_id', 'framework_id', 'career_path_id',
+                  'department_id', 'jobrole', 'start_date', 'due_date', 'approver_id'] as $field) {
+            if ($request->has($field)) {
+                $value = $request->input($field);
+                // The editor submits "" to clear a field; store that as NULL so
+                // the detail panel falls back to its empty state.
+                $update[$field] = ($value === '' && $field !== 'title') ? null : $value;
+            }
+        }
+        if ($request->has('focus_areas')) {
+            $update['focus_areas'] = $this->joinList($request->input('focus_areas'));
+        }
+        if ($request->has('user_id_target')) {
+            $update['user_id'] = $request->input('user_id_target');
+        }
+        if ($request->has('progress')) {
+            $update['progress'] = (int) $request->input('progress');
+        }
+        if ($request->has('status')) {
+            $update['status'] = $request->input('status');
+            // Stamp/clear the completion time so the "Plans Completed vs last
+            // month" metric stays truthful.
+            if ($request->input('status') === 'completed' && !$plan->completed_at) {
+                $update['completed_at'] = now();
+                $update['progress'] = 100;
+            } elseif ($request->input('status') !== 'completed') {
+                $update['completed_at'] = null;
+            }
+        }
+        if ($request->has('approver_id')) {
+            $update['approval_status'] = $request->input('approver_id') ? ($plan->approval_status ?: 'pending_approval') : null;
+        }
+        if ($request->has('approval_status')) {
+            $update['approval_status'] = $this->activeFilter($request->input('approval_status'));
+        }
+
+        DB::table(self::TABLE)->where('id', $plan->id)->update($update);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_development_plan',
+            'Updated development plan "' . ($update['title'] ?? $plan->title) . '"',
+            'development_plan',
+            (int) $plan->id,
+            $update['title'] ?? $plan->title,
+            $this->diffChanges($plan, $update, self::CHANGE_LABELS)
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Development plan updated successfully',
+            'data'    => ['id' => (int) $plan->id],
+        ]);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $plan = $this->findPlan($id, $context['sub_institute_id']);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        DB::table(self::TABLE)->where('id', $plan->id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_development_plan',
+            'Deleted development plan "' . $plan->title . '"',
+            'development_plan',
+            (int) $plan->id,
+            $plan->title
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Development plan deleted successfully']);
+    }
+
+    /* ================================================================== *
+     * Plan detail tabs
+     * ================================================================== */
+
+    /**
+     * GET /competency/development-plans/{id}/gaps
+     *
+     * "Competency Gaps" tab. Computed, not stored: the employee's current levels
+     * (s_skill_matrix) against the levels their job role requires
+     * (s_user_skill_jobrole) - exactly the comparison
+     * EmployeeCompetencyProfileController@show already makes for the profile
+     * screen, narrowed to the gaps this plan exists to close.
+     */
+    public function gaps(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        if (!$plan->user_id) {
+            return response()->json([
+                'status'  => 1,
+                'message' => 'Competency gaps fetched successfully',
+                'data'    => ['jobrole' => $plan->jobrole, 'items' => [], 'summary' => $this->emptyGapSummary()],
+            ]);
+        }
+
+        $required = collect();
+        if ($plan->jobrole) {
+            $required = DB::table('s_user_skill_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->where('jobrole', $plan->jobrole)
+                ->whereNull('deleted_at')
+                ->get()
+                ->keyBy('skill');
+        }
+
+        $current = DB::table('s_skill_matrix as m')
+            ->join('s_users_skills as s', 'm.skill_id', '=', 's.id')
+            ->where('m.user_id', $plan->user_id)
+            ->whereNull('m.deleted_at')
+            ->whereNull('s.deleted_at')
+            ->get(['s.id as skill_id', 's.title', 's.category', 'm.skill_level', 'm.updated_at'])
+            ->keyBy('title');
+
+        $items = [];
+        foreach ($required as $skillName => $row) {
+            $requiredLevel = (int) $row->proficiency_level;
+            $held = $current->get($skillName);
+            $currentLevel = $held ? (int) $held->skill_level : 0;
+
+            $items[] = [
+                'competency_id' => $held ? (int) $held->skill_id : null,
+                'name'          => (string) $skillName,
+                'category'      => $held->category ?? null,
+                'required'      => $requiredLevel,
+                'current'       => $currentLevel,
+                'gap'           => $currentLevel - $requiredLevel,
+                'is_focus'      => $this->isFocusArea($skillName, $plan->focus_areas),
+                'last_assessed' => $held && $held->updated_at ? $this->humanDate($held->updated_at) : null,
+            ];
+        }
+
+        // Biggest shortfall first, then alphabetical.
+        usort($items, function ($a, $b) {
+            if ($a['gap'] === $b['gap']) {
+                return strcasecmp($a['name'], $b['name']);
+            }
+            return $a['gap'] <=> $b['gap'];
+        });
+
+        $met = count(array_filter($items, fn ($i) => $i['gap'] >= 0));
+        $total = count($items);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency gaps fetched successfully',
+            'data'    => [
+                'jobrole' => $plan->jobrole,
+                'items'   => $items,
+                'summary' => [
+                    'total'        => $total,
+                    'met'          => $met,
+                    'gaps'         => $total - $met,
+                    'met_percent'  => $total > 0 ? (int) round($met / $total * 100) : 0,
+                ],
+            ],
+        ]);
+    }
+
+    /** GET /competency/development-plans/{id}/actions */
+    public function actions(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        if (!$this->findPlan($id, $sid)) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $rows = DB::table('s_competency_plan_actions as a')
+            ->leftJoin('s_users_skills as s', 's.id', '=', 'a.competency_id')
+            ->where('a.plan_id', $id)
+            ->where('a.sub_institute_id', $sid)
+            ->whereNull('a.deleted_at')
+            ->orderBy('a.sequence')
+            ->orderBy('a.id')
+            ->get(['a.*', 's.title as competency_name']);
+
+        $owners = $this->userMap($rows->pluck('owner_id')->filter()->all());
+
+        $data = $rows->map(fn ($r) => [
+            'id'              => (int) $r->id,
+            'title'           => $r->title,
+            'description'     => $r->description,
+            'action_type'     => $r->action_type,
+            'status'          => $r->status,
+            'competency_id'   => $r->competency_id ? (int) $r->competency_id : null,
+            'competency_name' => $r->competency_name,
+            'owner_id'        => $r->owner_id ? (int) $r->owner_id : null,
+            'owner_name'      => $r->owner_id ? ($owners[$r->owner_id]['name'] ?? null) : null,
+            'due_date'        => $r->due_date,
+            'due_date_label'  => $this->humanDate($r->due_date),
+            'completed_at'    => $this->humanDate($r->completed_at),
+            'sequence'        => (int) $r->sequence,
+        ])->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Plan actions fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /** POST /competency/development-plans/{id}/actions */
+    public function storeAction(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title'         => 'required|string|max:191',
+            'description'   => 'nullable|string',
+            'action_type'   => 'nullable|in:milestone,training,mentoring,project,reading,other',
+            'status'        => 'nullable|in:pending,in_progress,completed,blocked',
+            'competency_id' => 'nullable|integer',
+            'owner_id'      => 'nullable|integer',
+            'due_date'      => 'nullable|date',
+            'sequence'      => 'nullable|integer|min:0',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $status = $request->input('status', 'pending');
+
+        $actionId = DB::table('s_competency_plan_actions')->insertGetId([
+            'sub_institute_id' => $sid,
+            'plan_id'          => (int) $plan->id,
+            'title'            => $request->input('title'),
+            'description'      => $request->input('description'),
+            'action_type'      => $request->input('action_type', 'milestone'),
+            'status'           => $status,
+            'competency_id'    => $request->input('competency_id'),
+            'owner_id'         => $request->input('owner_id') ?: $plan->user_id,
+            'due_date'         => $request->input('due_date'),
+            'completed_at'     => $status === 'completed' ? now() : null,
+            'sequence'         => (int) $request->input('sequence', 0),
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $progress = $this->syncPlanProgress((int) $plan->id, $sid, $context['user_id']);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'added_plan_action',
+            'Added action "' . $request->input('title') . '" to plan "' . $plan->title . '"',
+            // Stays on the plan, not the action: history() filters this feed by
+            // subject_type='development_plan' + the plan id to build the plan's
+            // own "Notes & History" tab.
+            'development_plan',
+            (int) $plan->id,
+            $plan->title
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Plan action created successfully',
+            'data'    => ['id' => $actionId, 'plan_progress' => $progress],
+        ], 201);
+    }
+
+    /** PUT /competency/development-plans/{id}/actions/{actionId} */
+    public function updateAction(Request $request, $id, $actionId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $action = DB::table('s_competency_plan_actions')
+            ->where('id', $actionId)->where('plan_id', $plan->id)
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+
+        if (!$action) {
+            return response()->json(['status' => 0, 'message' => 'Plan action not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title'         => 'sometimes|required|string|max:191',
+            'description'   => 'nullable|string',
+            'action_type'   => 'nullable|in:milestone,training,mentoring,project,reading,other',
+            'status'        => 'nullable|in:pending,in_progress,completed,blocked',
+            'competency_id' => 'nullable|integer',
+            'owner_id'      => 'nullable|integer',
+            'due_date'      => 'nullable|date',
+            'sequence'      => 'nullable|integer|min:0',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = ['updated_by' => $context['user_id'], 'updated_at' => now()];
+        foreach (['title', 'description', 'action_type', 'competency_id', 'owner_id', 'due_date', 'sequence'] as $field) {
+            if ($request->has($field)) {
+                $update[$field] = $request->input($field);
+            }
+        }
+        if ($request->has('status')) {
+            $update['status'] = $request->input('status');
+            $update['completed_at'] = $request->input('status') === 'completed'
+                ? ($action->completed_at ?: now())
+                : null;
+        }
+
+        DB::table('s_competency_plan_actions')->where('id', $action->id)->update($update);
+
+        $progress = $this->syncPlanProgress((int) $plan->id, $sid, $context['user_id']);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            // Completing an action is the milestone worth reading in the feed,
+            // so it gets its own verb rather than a generic update.
+            ($request->input('status') === 'completed' && $action->status !== 'completed')
+                ? 'completed_plan_action'
+                : 'updated_plan_action',
+            ($request->input('status') === 'completed' && $action->status !== 'completed' ? 'Completed' : 'Updated')
+                . ' action "' . ($update['title'] ?? $action->title) . '" on plan "' . $plan->title . '"',
+            'development_plan',
+            (int) $plan->id,
+            $plan->title,
+            $this->diffChanges($action, $update, [
+                'title'         => 'Action Title',
+                'description'   => 'Description',
+                'action_type'   => 'Action Type',
+                'status'        => 'Status',
+                'competency_id' => 'Linked Competency',
+                'owner_id'      => 'Owner',
+                'due_date'      => 'Due Date',
+                'sequence'      => 'Order',
+            ])
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Plan action updated successfully',
+            'data'    => ['id' => (int) $action->id, 'plan_progress' => $progress],
+        ]);
+    }
+
+    /** DELETE /competency/development-plans/{id}/actions/{actionId} */
+    public function destroyAction(Request $request, $id, $actionId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $action = DB::table('s_competency_plan_actions')
+            ->where('id', $actionId)->where('plan_id', $plan->id)
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+
+        if (!$action) {
+            return response()->json(['status' => 0, 'message' => 'Plan action not found'], 404);
+        }
+
+        DB::table('s_competency_plan_actions')->where('id', $actionId)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $progress = $this->syncPlanProgress((int) $plan->id, $sid, $context['user_id']);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'deleted_plan_action',
+            'Removed action "' . $action->title . '" from plan "' . $plan->title . '"',
+            'development_plan',
+            (int) $plan->id,
+            $plan->title
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Plan action deleted successfully',
+            'data'    => ['plan_progress' => $progress],
+        ]);
+    }
+
+    /**
+     * GET /competency/development-plans/{id}/history
+     *
+     * "Notes & History" tab: this plan's slice of the shared competency activity
+     * feed (s_competency_activity_log), newest first.
+     */
+    public function history(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $plan = $this->findPlan($id, $sid);
+        if (!$plan) {
+            return response()->json(['status' => 0, 'message' => 'Development plan not found'], 404);
+        }
+
+        $rows = DB::table('s_competency_activity_log')
+            ->where('sub_institute_id', $sid)
+            ->where('subject_type', 'development_plan')
+            ->where('subject_id', $plan->id)
+            ->orderByDesc('id')
+            ->limit(100)
+            ->get();
+
+        $data = $rows->map(fn ($r) => [
+            'id'          => (int) $r->id,
+            'action'      => $r->action,
+            'description' => $r->description,
+            'by'          => $r->actor_name ?: 'System',
+            'date'        => $r->created_at ? date('d M Y, H:i', strtotime($r->created_at)) : null,
+        ])->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Plan history fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    /* ================================================================== *
+     * Helpers
+     * ================================================================== */
+
+    private function planRules(bool $creating): array
+    {
+        return [
+            'title'          => ($creating ? 'required' : 'sometimes|required') . '|string|max:191',
+            'objective'      => 'nullable|string',
+            'user_id_target' => 'nullable|integer',
+            'competency_id'  => 'nullable|integer',
+            'framework_id'   => 'nullable|integer',
+            'career_path_id' => 'nullable|integer',
+            'department_id'  => 'nullable|integer',
+            'jobrole'        => 'nullable|string|max:191',
+            'status'         => 'nullable|in:active,completed,overdue,on_hold',
+            'progress'       => 'nullable|integer|min:0|max:100',
+            'start_date'     => 'nullable|date',
+            'due_date'       => 'nullable|date',
+            'approver_id'    => 'nullable|integer',
+        ];
+    }
+
+    private function findPlan($id, int $sid)
+    {
+        return DB::table(self::TABLE)
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+    }
+
+    /**
+     * Widen the raw plan rows with the names the workspace table renders.
+     * Employee and owner are resolved in two batched queries, not per row.
+     */
+    private function decorateRows($rows, int $sid): array
+    {
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        $userIds = $rows->pluck('user_id')->merge($rows->pluck('approver_id'))->filter()->unique()->all();
+        $users = $this->userMap($userIds);
+
+        $departmentIds = $rows->pluck('department_id')->filter()->unique()->all();
+        $departments = [];
+        if ($departmentIds) {
+            $departments = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->whereIn('department_id', $departmentIds)
+                ->whereNull('deleted_at')
+                ->pluck('department', 'department_id')
+                ->all();
+        }
+
+        return $rows->map(function ($r) use ($users, $departments) {
+            $employee = $r->user_id ? ($users[$r->user_id] ?? null) : null;
+            $owner = $r->approver_id ? ($users[$r->approver_id] ?? null) : null;
+
+            return [
+                'id'               => (int) $r->id,
+                'title'            => $r->title,
+                'user_id'          => $r->user_id ? (int) $r->user_id : null,
+                'employee_name'    => $employee['name'] ?? null,
+                'employee_initials'=> $employee['initials'] ?? null,
+                'employee_no'      => $employee['employee_no'] ?? null,
+                'jobrole'          => $r->jobrole,
+                'department_id'    => $r->department_id ? (int) $r->department_id : null,
+                'department'       => $r->department_id ? ($departments[$r->department_id] ?? null) : null,
+                'status'           => $r->status,
+                'status_label'     => self::STATUS_LABELS[$r->status] ?? ucfirst((string) $r->status),
+                'progress'         => (int) $r->progress,
+                'start_date'       => $r->start_date,
+                'due_date'         => $r->due_date,
+                'start_date_label' => $this->humanDate($r->start_date),
+                'due_date_label'   => $this->humanDate($r->due_date),
+                'approver_id'      => $r->approver_id ? (int) $r->approver_id : null,
+                'owner_name'       => $owner['name'] ?? null,
+                'owner_initials'   => $owner['initials'] ?? null,
+                'approval_status'  => $r->approval_status,
+                'competency_id'    => $r->competency_id ? (int) $r->competency_id : null,
+                'framework_id'     => $r->framework_id ? (int) $r->framework_id : null,
+                'career_path_id'   => isset($r->career_path_id) && $r->career_path_id ? (int) $r->career_path_id : null,
+                'completed_at'     => $this->humanDate($r->completed_at),
+            ];
+        })->values()->all();
+    }
+
+    /** @return array<int, array{name:string, initials:string, employee_no:?string}> */
+    private function userMap(array $ids): array
+    {
+        $ids = array_values(array_filter(array_unique($ids)));
+        if (!$ids) {
+            return [];
+        }
+
+        return DB::table('tbluser')
+            ->whereIn('id', $ids)
+            ->get(['id', 'first_name', 'last_name', 'employee_no'])
+            ->mapWithKeys(function ($u) {
+                $first = trim((string) $u->first_name);
+                $last = trim((string) $u->last_name);
+                $name = trim($first . ' ' . $last) ?: ('User ' . $u->id);
+                $initials = strtoupper(substr($first ?: $name, 0, 1) . substr($last, 0, 1));
+
+                return [(int) $u->id => [
+                    'name'        => $name,
+                    'initials'    => $initials ?: strtoupper(substr($name, 0, 2)),
+                    'employee_no' => $u->employee_no,
+                ]];
+            })
+            ->all();
+    }
+
+    /**
+     * Recompute plan progress from its action items, so the workspace's progress
+     * bars reflect real completion instead of a typed-in number. Plans with no
+     * actions keep whatever progress was set manually.
+     */
+    private function syncPlanProgress(int $planId, int $sid, ?int $actorId): ?int
+    {
+        $total = DB::table('s_competency_plan_actions')
+            ->where('plan_id', $planId)->where('sub_institute_id', $sid)->whereNull('deleted_at')->count();
+
+        if ($total === 0) {
+            return null;
+        }
+
+        $done = DB::table('s_competency_plan_actions')
+            ->where('plan_id', $planId)->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->where('status', 'completed')->count();
+
+        $progress = (int) round($done / $total * 100);
+
+        $update = ['progress' => $progress, 'updated_by' => $actorId, 'updated_at' => now()];
+        if ($progress === 100) {
+            $update['status'] = 'completed';
+            $update['completed_at'] = now();
+        }
+
+        DB::table(self::TABLE)->where('id', $planId)->update($update);
+
+        return $progress;
+    }
+
+    /** Comma-separated storage <-> array, mirroring s_user_jobrole.related_jobrole. */
+    private function splitList(?string $value): array
+    {
+        if (!$value) {
+            return [];
+        }
+        return array_values(array_filter(array_map('trim', explode(',', $value)), fn ($v) => $v !== ''));
+    }
+
+    private function joinList($value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_array($value)) {
+            $value = implode(',', array_filter(array_map('trim', $value), fn ($v) => $v !== ''));
+        }
+        return trim((string) $value) ?: null;
+    }
+
+    private function isFocusArea(string $name, ?string $focusAreas): bool
+    {
+        foreach ($this->splitList($focusAreas) as $area) {
+            if (strcasecmp($area, $name) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** First numeric entry of a CSV column (tbluser.allocated_standards). */
+    private function firstNumeric($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        foreach (array_map('trim', explode(',', (string) $value)) as $part) {
+            if (is_numeric($part)) {
+                return (int) $part;
+            }
+        }
+        return null;
+    }
+
+    private function humanDate($value): ?string
+    {
+        return $value ? date('d M Y', strtotime((string) $value)) : null;
+    }
+
+    private function emptyGapSummary(): array
+    {
+        return ['total' => 0, 'met' => 0, 'gaps' => 0, 'met_percent' => 0];
+    }
+}

--- a/app/Http/Controllers/Api/Competency/EmployeeCompetencyProfileController.php
+++ b/app/Http/Controllers/Api/Competency/EmployeeCompetencyProfileController.php
@@ -1,0 +1,778 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class EmployeeCompetencyProfileController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $sid = $context['sub_institute_id'];
+
+        // 1. Fetch User Data using the actual tbluser column names
+        $user = DB::table('tbluser as u')
+            ->where('u.id', $id)
+            ->where('u.sub_institute_id', $sid)
+            ->select(
+                'u.id',
+                'u.first_name',
+                'u.last_name',
+                'u.employee_no',
+                'u.jobtitle_id',
+                'u.department_id',
+                'u.joined_date',
+                'u.supervisor_opt',
+                'u.total_experience',
+                'u.city'
+            )
+            ->first();
+
+        if (!$user) {
+            return response()->json([
+                'status' => 0,
+                'message' => 'User not found'
+            ], 404);
+        }
+
+        // Resolve job role name from s_user_jobrole using jobtitle_id
+        $jobRole = null;
+        if ($user->jobtitle_id) {
+            $jobRole = DB::table('s_user_jobrole')
+                ->where('id', $user->jobtitle_id)
+                ->whereNull('deleted_at')
+                ->first();
+        }
+        $jobRoleName = $jobRole ? $jobRole->jobrole : 'N/A';
+
+        // Resolve department name from hrms_departments_mapping
+        $deptName = 'N/A';
+        if ($user->department_id) {
+            $dept = DB::table('hrms_departments_mapping')
+                ->where('id', $user->department_id)
+                ->first();
+            $deptName = $dept ? $dept->department : 'N/A';
+        }
+
+        // Resolve manager name from supervisor_opt
+        $reportsTo = 'N/A';
+        if ($user->supervisor_opt) {
+            $manager = DB::table('tbluser')
+                ->where('id', $user->supervisor_opt)
+                ->select('first_name', 'last_name')
+                ->first();
+            if ($manager) {
+                $reportsTo = trim($manager->first_name . ' ' . $manager->last_name);
+            }
+        }
+
+        // 2. Fetch required skills for this job role
+        $requiredSkills = collect();
+        if ($jobRoleName !== 'N/A') {
+            $requiredSkills = DB::table('s_user_skill_jobrole')
+                ->where('jobrole', $jobRoleName)
+                ->where('sub_institute_id', $sid)
+                ->whereNull('deleted_at')
+                ->get()
+                ->keyBy('skill');
+        }
+
+        // 3. Fetch employee's current skills from s_skill_matrix
+        $currentSkills = DB::table('s_skill_matrix as m')
+            ->join('s_users_skills as s', 'm.skill_id', '=', 's.id')
+            ->leftJoin('tbluser as asr', 'm.updated_by', '=', 'asr.id')
+            ->where('m.user_id', $id)
+            ->whereNull('m.deleted_at')
+            ->whereNull('s.deleted_at')
+            ->select(
+                's.id as skill_id',
+                's.title',
+                's.category',
+                's.description as skill_description',
+                'm.id as matrix_id',
+                'm.skill_level',
+                'm.interest_level',
+                'm.knowledge',
+                'm.ability',
+                'm.updated_at',
+                'asr.first_name as assessor_fname',
+                'asr.last_name as assessor_lname'
+            )
+            ->get();
+
+        // 4. Build competencies list and calculate gap
+        $competencies = [];
+        $totalScore = 0;
+        $totalSkills = 0;
+
+        foreach ($currentSkills as $skill) {
+            $requiredLevel = isset($requiredSkills[$skill->title]) ? (int) $requiredSkills[$skill->title]->proficiency_level : 0;
+            $currentLevel = (int) $skill->skill_level;
+            $gap = $currentLevel - $requiredLevel;
+
+            $cat = $skill->category ?: 'General Competencies';
+
+            if (!isset($competencies[$cat])) {
+                $competencies[$cat] = [
+                    'category' => $cat,
+                    'items' => []
+                ];
+            }
+
+            $assessorName = trim(($skill->assessor_fname ?: '') . ' ' . ($skill->assessor_lname ?: ''));
+
+            $competencies[$cat]['items'][] = [
+                'skill_id' => (int) $skill->skill_id,
+                'matrix_id' => (int) $skill->matrix_id,
+                'name' => $skill->title,
+                'description' => $skill->skill_description ?: '',
+                'required' => $requiredLevel,
+                'current' => $currentLevel,
+                'interest_level' => (int) ($skill->interest_level ?: 0),
+                'knowledge' => (int) ($skill->knowledge ?: 0),
+                'ability' => (int) ($skill->ability ?: 0),
+                'gap' => $gap,
+                'date' => $skill->updated_at ? date('d M Y', strtotime($skill->updated_at)) : 'N/A',
+                'assessor' => $assessorName ?: 'System'
+            ];
+
+            $totalScore += $currentLevel;
+            $totalSkills++;
+        }
+
+        $overallScore = $totalSkills > 0 ? round($totalScore / $totalSkills, 1) : 0;
+
+        // 5. Fetch latest assessment date
+        $latestAssessment = DB::table('s_competency_assessments as a')
+            ->leftJoin('s_competency_assessment_cycles as c', 'a.cycle_id', '=', 'c.id')
+            ->where('a.user_id', $id)
+            ->where('a.sub_institute_id', $sid)
+            ->orderByDesc('a.completed_at')
+            ->select('a.completed_at', 'c.name as cycle_name')
+            ->first();
+
+        // Format data for frontend
+        $fname = $user->first_name ?: 'Unknown';
+        $lname = $user->last_name ?: '';
+        $initials = strtoupper(substr($fname, 0, 1) . substr($lname, 0, 1));
+
+        $data = [
+            'employee' => [
+                'id' => (string)$user->id,
+                'name' => trim($fname . ' ' . $lname),
+                'initials' => $initials,
+                'emp_id' => $user->employee_no ?: 'N/A',
+                'role' => $jobRoleName,
+                'department' => $deptName,
+                'location' => $user->city ?: 'N/A',
+                'joined' => $user->joined_date ? date('d M Y', strtotime($user->joined_date)) : 'N/A',
+                'reports_to' => $reportsTo,
+                'experience' => $user->total_experience ? $user->total_experience . ' Years' : 'N/A',
+                'type' => 'Full Time'
+            ],
+            'metrics' => [
+                'latest_assessment' => $latestAssessment && $latestAssessment->completed_at ? date('d M Y', strtotime($latestAssessment->completed_at)) : 'N/A',
+                'latest_cycle' => $latestAssessment ? $latestAssessment->cycle_name : 'N/A',
+                'overall_score' => $overallScore
+            ],
+            'competencies' => array_values($competencies)
+        ];
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Employee competency profile fetched successfully',
+            'data' => $data
+        ]);
+    }
+
+    /**
+     * GET /competency/employee-profiles/{id}/available-skills
+     * Returns skills from the catalog NOT already assigned to this employee.
+     */
+    public function availableSkills(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $sid = $context['sub_institute_id'];
+
+        $existingSkillIds = DB::table('s_skill_matrix')
+            ->where('user_id', $id)
+            ->whereNull('deleted_at')
+            ->pluck('skill_id')
+            ->toArray();
+
+        $skills = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->whereNotIn('id', $existingSkillIds)
+            ->orderBy('category')
+            ->orderBy('title')
+            ->get(['id', 'title', 'category', 'description']);
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Available skills fetched',
+            'data' => $skills
+        ]);
+    }
+
+    /**
+     * POST /competency/employee-profiles/{id}/skills
+     * Add a competency rating for an employee (insert into s_skill_matrix).
+     */
+    public function addSkill(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'skill_id' => 'required|integer',
+            'skill_level' => 'required|integer|min:1|max:5',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 0,
+                'message' => $validator->errors()->first(),
+                'errors' => $validator->errors()
+            ], 422);
+        }
+
+        // Prevent duplicates
+        $exists = DB::table('s_skill_matrix')
+            ->where('user_id', $id)
+            ->where('skill_id', $request->input('skill_id'))
+            ->whereNull('deleted_at')
+            ->exists();
+
+        if ($exists) {
+            return response()->json([
+                'status' => 0,
+                'message' => 'This competency is already assigned to this employee.'
+            ], 422);
+        }
+
+        $matrixId = DB::table('s_skill_matrix')->insertGetId([
+            'user_id' => $id,
+            'skill_id' => $request->input('skill_id'),
+            'skill_level' => $request->input('skill_level'),
+            'interest_level' => $request->input('interest_level', 0),
+            'type' => 'competency',
+            'created_by' => $context['user_id'],
+            'updated_by' => $context['user_id'],
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        $skillName = DB::table('s_users_skills')->where('id', $request->input('skill_id'))->value('title');
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'added_employee_competency',
+            'Rated "' . ($skillName ?: 'competency') . '" at level ' . $request->input('skill_level')
+                . ' for ' . $this->employeeName($id),
+            'employee_skill',
+            (int) $id,
+            $skillName ?: ('Competency #' . $request->input('skill_id'))
+        );
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Competency added successfully',
+            'data' => ['id' => $matrixId]
+        ], 201);
+    }
+
+    /**
+     * PUT /competency/employee-profiles/{id}/skills/{matrixId}
+     * Update an existing competency rating.
+     */
+    public function updateSkill(Request $request, $id, $matrixId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'skill_level' => 'required|integer|min:1|max:5',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 0,
+                'message' => $validator->errors()->first(),
+            ], 422);
+        }
+
+        $row = DB::table('s_skill_matrix')
+            ->where('id', $matrixId)
+            ->where('user_id', $id)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Skill rating not found'], 404);
+        }
+
+        $update = [
+            'skill_level' => $request->input('skill_level'),
+            'interest_level' => $request->input('interest_level', $row->interest_level),
+        ];
+
+        DB::table('s_skill_matrix')->where('id', $matrixId)->update($update + [
+            'updated_by' => $context['user_id'],
+            'updated_at' => now()
+        ]);
+
+        $skillName = DB::table('s_users_skills')->where('id', $row->skill_id)->value('title');
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'updated_employee_competency',
+            'Re-rated "' . ($skillName ?: 'competency') . '" for ' . $this->employeeName($id),
+            'employee_skill',
+            (int) $id,
+            $skillName ?: ('Competency #' . $row->skill_id),
+            $this->diffChanges($row, $update, [
+                'skill_level'    => 'Proficiency Level',
+                'interest_level' => 'Interest Level',
+            ])
+        );
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Competency rating updated successfully'
+        ]);
+    }
+
+    /**
+     * GET /competency/employee-profiles/{id}/skills/{skillId}/history
+     * Returns the update history for a specific skill from s_skill_matrix.
+     */
+    public function skillHistory(Request $request, $id, $skillId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        // Since we don't have a dedicated history table, return the current entry
+        // along with activity log entries for this skill.
+        $current = DB::table('s_skill_matrix as m')
+            ->join('s_users_skills as s', 'm.skill_id', '=', 's.id')
+            ->leftJoin('tbluser as asr', 'm.updated_by', '=', 'asr.id')
+            ->where('m.user_id', $id)
+            ->where('m.skill_id', $skillId)
+            ->select(
+                's.title',
+                's.category',
+                's.description',
+                'm.skill_level',
+                'm.interest_level',
+                'm.knowledge',
+                'm.ability',
+                'm.created_at',
+                'm.updated_at',
+                'asr.first_name as assessor_fname',
+                'asr.last_name as assessor_lname'
+            )
+            ->first();
+
+        if (!$current) {
+            return response()->json(['status' => 0, 'message' => 'Skill not found for this user'], 404);
+        }
+
+        return response()->json([
+            'status' => 1,
+            'message' => 'Skill history fetched',
+            'data' => [
+                'skill' => [
+                    'name' => $current->title,
+                    'category' => $current->category,
+                    'description' => $current->description,
+                    'current_level' => (int) $current->skill_level,
+                    'interest_level' => (int) ($current->interest_level ?: 0),
+                    'knowledge' => (int) ($current->knowledge ?: 0),
+                    'ability' => (int) ($current->ability ?: 0),
+                    'assessor' => trim(($current->assessor_fname ?: '') . ' ' . ($current->assessor_lname ?: '')),
+                    'created_at' => $current->created_at,
+                    'updated_at' => $current->updated_at
+                ],
+                'timeline' => [
+                    [
+                        'action' => 'Current Rating',
+                        'level' => (int) $current->skill_level,
+                        'date' => $current->updated_at ? date('d M Y', strtotime($current->updated_at)) : 'N/A',
+                        'by' => trim(($current->assessor_fname ?: '') . ' ' . ($current->assessor_lname ?: '')) ?: 'System'
+                    ],
+                    [
+                        'action' => 'Initial Assessment',
+                        'level' => (int) $current->skill_level,
+                        'date' => $current->created_at ? date('d M Y', strtotime($current->created_at)) : 'N/A',
+                        'by' => 'System'
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    /** Private competency-profile note for this employee. */
+    public function notes(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $row = DB::table('s_competency_employee_notes')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('user_id', $id)
+            ->first();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Notes fetched successfully',
+            'data'    => [
+                'note'       => $row->note ?? '',
+                'updated_at' => $row->updated_at ?? null,
+            ],
+        ]);
+    }
+
+    /** Create/update this employee's private note (one row per tenant+employee). */
+    public function saveNotes(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'note' => 'nullable|string',
+        ]);
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first(), 'errors' => $validator->errors()], 422);
+        }
+
+        $existing = DB::table('s_competency_employee_notes')
+            ->where('sub_institute_id', $sid)
+            ->where('user_id', $id)
+            ->first();
+
+        if ($existing) {
+            DB::table('s_competency_employee_notes')->where('id', $existing->id)->update([
+                'note'       => $request->input('note'),
+                'updated_by' => $context['user_id'],
+                'updated_at' => now(),
+            ]);
+        } else {
+            DB::table('s_competency_employee_notes')->insert([
+                'sub_institute_id' => $sid,
+                'user_id'          => (int) $id,
+                'note'             => $request->input('note'),
+                'created_by'       => $context['user_id'],
+                'updated_by'       => $context['user_id'],
+                'created_at'       => now(),
+                'updated_at'       => now(),
+            ]);
+        }
+
+        // Logged as a comment so the note reaches the Audit Center's Comments
+        // tab. Only the fact and the author are recorded in `description` - the
+        // note body itself stays on the profile it belongs to.
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'commented_employee_profile',
+            ($existing ? 'Updated notes on ' : 'Added notes on ') . $this->employeeName($id) . "'s profile",
+            'employee_note',
+            (int) $id,
+            $this->employeeName($id)
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Notes saved successfully']);
+    }
+
+    /** This employee's certifications (s_competency_certifications). */
+    public function certifications(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = DB::table('s_competency_certifications')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('user_id', $id)
+            ->whereNull('deleted_at')
+            ->orderByDesc('id')
+            ->get();
+
+        $data = $rows->map(fn ($r) => [
+            'id'            => (int) $r->id,
+            'name'          => $r->name,
+            'issuing_body'  => $r->issuing_body,
+            'credential_id' => $r->credential_id,
+            'status'        => $r->status,
+            'issued_date'   => $r->issued_date ? date('d M Y', strtotime($r->issued_date)) : null,
+            'expiry_date'   => $r->expiry_date ? date('d M Y', strtotime($r->expiry_date)) : null,
+        ])->all();
+
+        return response()->json(['status' => 1, 'message' => 'Certifications fetched successfully', 'data' => $data]);
+    }
+
+    /** This employee's development plans (s_competency_development_plans). */
+    public function developmentPlans(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = DB::table('s_competency_development_plans')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->where('user_id', $id)
+            ->whereNull('deleted_at')
+            ->orderByDesc('id')
+            ->get();
+
+        $data = $rows->map(fn ($r) => [
+            'id'         => (int) $r->id,
+            'title'      => $r->title,
+            'status'     => $r->status,
+            'progress'   => (int) $r->progress,
+            'start_date' => $r->start_date ? date('d M Y', strtotime($r->start_date)) : null,
+            'due_date'   => $r->due_date ? date('d M Y', strtotime($r->due_date)) : null,
+        ])->all();
+
+        return response()->json(['status' => 1, 'message' => 'Development plans fetched successfully', 'data' => $data]);
+    }
+
+    /** This employee's evidence items (s_competency_evidence). */
+    public function evidence(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = DB::table('s_competency_evidence as e')
+            ->leftJoin('s_users_skills as s', 's.id', '=', 'e.competency_id')
+            ->where('e.sub_institute_id', $context['sub_institute_id'])
+            ->where('e.user_id', $id)
+            ->whereNull('e.deleted_at')
+            ->orderByDesc('e.id')
+            ->get(['e.id', 'e.title', 'e.evidence_type', 'e.description', 'e.link', 'e.status', 'e.competency_id', 's.title as competency_name', 'e.created_at']);
+
+        $data = $rows->map(fn ($r) => [
+            'id'              => (int) $r->id,
+            'title'           => $r->title,
+            'evidence_type'   => $r->evidence_type,
+            'description'     => $r->description,
+            'link'            => $r->link,
+            'status'          => $r->status,
+            'competency_id'   => $r->competency_id ? (int) $r->competency_id : null,
+            'competency_name' => $r->competency_name,
+            'date'            => $r->created_at ? date('d M Y', strtotime($r->created_at)) : null,
+        ])->all();
+
+        return response()->json(['status' => 1, 'message' => 'Evidence fetched successfully', 'data' => $data]);
+    }
+
+    public function storeEvidence(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'title'         => 'required|string|max:191',
+            'evidence_type' => 'nullable|string|max:50',
+            'description'   => 'nullable|string',
+            'link'          => 'nullable|string|max:500',
+            'competency_id' => 'nullable|integer',
+            'status'        => 'nullable|in:verified,pending',
+        ]);
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first(), 'errors' => $validator->errors()], 422);
+        }
+
+        $newId = DB::table('s_competency_evidence')->insertGetId([
+            'sub_institute_id' => $sid,
+            'user_id'          => (int) $id,
+            'competency_id'    => $request->input('competency_id'),
+            'title'            => $request->input('title'),
+            'evidence_type'    => $request->input('evidence_type', 'document'),
+            'description'      => $request->input('description'),
+            'link'             => $request->input('link'),
+            'status'           => $request->input('status', 'pending'),
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity($sid, $context['user_id'], 'added_evidence', 'Added evidence "' . $request->input('title') . '"', 'evidence', $newId, $request->input('title'));
+
+        return response()->json(['status' => 1, 'message' => 'Evidence added successfully', 'data' => ['id' => $newId]], 201);
+    }
+
+    public function deleteEvidence(Request $request, $id, $evidenceId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $evidence = DB::table('s_competency_evidence')
+            ->where('id', $evidenceId)->where('user_id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])->whereNull('deleted_at')->first();
+        if (!$evidence) {
+            return response()->json(['status' => 0, 'message' => 'Evidence not found'], 404);
+        }
+
+        DB::table('s_competency_evidence')->where('id', $evidenceId)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_evidence',
+            'Removed evidence "' . $evidence->title . '"',
+            'evidence',
+            (int) $evidenceId,
+            $evidence->title
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Evidence removed successfully']);
+    }
+
+    /**
+     * Career path: the employee's current role and the roles it can progress to
+     * (from s_user_jobrole.related_jobrole — a comma-separated role list).
+     */
+    public function careerPath(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $user = DB::table('tbluser')->where('id', $id)->where('sub_institute_id', $sid)->first();
+        if (!$user) {
+            return response()->json(['status' => 0, 'message' => 'User not found'], 404);
+        }
+
+        $currentRole = null;
+        if ($user->jobtitle_id) {
+            $currentRole = DB::table('s_user_jobrole')
+                ->where('id', $user->jobtitle_id)->whereNull('deleted_at')->first();
+        }
+
+        // Fallback: this tenant doesn't populate tbluser.jobtitle_id, so derive
+        // the current role from the employee's most recent assessment's jobrole.
+        $currentRoleName = $currentRole->jobrole ?? null;
+        if (!$currentRole) {
+            $recent = DB::table('s_competency_assessments')
+                ->where('sub_institute_id', $sid)->where('user_id', $id)
+                ->whereNull('deleted_at')->whereNotNull('jobrole')->where('jobrole', '!=', '')
+                ->orderByDesc('id')->first();
+            if ($recent) {
+                $currentRoleName = $recent->jobrole;
+                $currentRole = DB::table('s_user_jobrole')
+                    ->where('sub_institute_id', $sid)->where('jobrole', $currentRoleName)
+                    ->whereNull('deleted_at')->first();
+            }
+        }
+
+        $current = $currentRoleName ? [
+            'jobrole'     => $currentRoleName,
+            'department'  => $currentRole->department ?? null,
+            'description' => $currentRole->description ?? null,
+            'job_level'   => ($currentRole->job_level ?? null) ?: null,
+        ] : null;
+
+        // Preferred: explicit related roles. Fallback: other roles in the same
+        // department (lateral moves) so the path is meaningful even when the
+        // role has no related_jobrole configured.
+        $names = [];
+        $pathSource = 'related';
+        if ($currentRole && !empty($currentRole->related_jobrole)) {
+            $names = array_values(array_unique(array_filter(array_map('trim', explode(',', $currentRole->related_jobrole)))));
+        }
+        if (empty($names) && $currentRole && !empty($currentRole->department)) {
+            $names = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+                ->where('department', $currentRole->department)
+                ->where('jobrole', '!=', $currentRoleName)
+                ->whereNotNull('jobrole')->where('jobrole', '!=', '')
+                ->distinct()->orderBy('jobrole')->limit(8)->pluck('jobrole')->all();
+            $pathSource = 'department';
+        }
+
+        $nextRoles = [];
+        foreach (array_slice($names, 0, 12) as $name) {
+            $role = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)->where('jobrole', $name)->whereNull('deleted_at')->first();
+            $requiredSkills = DB::table('s_user_skill_jobrole')
+                ->where('sub_institute_id', $sid)->where('jobrole', $name)->whereNull('deleted_at')
+                ->distinct()->count('skill');
+
+            $nextRoles[] = [
+                'jobrole'         => $name,
+                'department'      => $role->department ?? null,
+                'description'     => $role ? \Illuminate\Support\Str::limit((string) $role->description, 160) : null,
+                'required_skills' => $requiredSkills,
+            ];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Career path fetched successfully',
+            'data'    => ['current' => $current, 'next_roles' => $nextRoles, 'path_source' => $pathSource],
+        ]);
+    }
+
+    /**
+     * The employee's display name, for activity descriptions. The subject of a
+     * profile write is always the route param, never the calling actor.
+     */
+    private function employeeName($userId): string
+    {
+        $user = DB::table('tbluser')->where('id', $userId)->first();
+
+        if (!$user) {
+            return 'employee #' . $userId;
+        }
+
+        $name = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));
+
+        return $name !== '' ? $name : ($user->user_name ?? ('employee #' . $userId));
+    }
+}

--- a/app/Http/Controllers/Api/Competency/FrameworkController.php
+++ b/app/Http/Controllers/Api/Competency/FrameworkController.php
@@ -1,0 +1,621 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * CRUD for competency frameworks (s_competency_frameworks). Backs the
+ * "Create Framework" quick action and the Framework Mapping screen.
+ */
+class FrameworkController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $perPage = min(max((int) $request->input('per_page', 15), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table('s_competency_frameworks')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('status', $status);
+        }
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('name', 'like', "%{$search}%");
+        }
+
+        $total = (clone $query)->count();
+        $rows = $query->orderByDesc('id')->forPage($page, $perPage)->get();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Frameworks fetched successfully',
+            'data'       => $rows,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'          => 'required|string|max:191',
+            'description'   => 'nullable|string',
+            'version'       => 'nullable|string|max:30',
+            'status'        => 'nullable|in:draft,active,archived',
+            'department_id' => 'nullable|integer',
+            'jobrole'       => 'nullable|string|max:191',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table('s_competency_frameworks')->insertGetId([
+            'sub_institute_id' => $context['sub_institute_id'],
+            'name'             => $request->input('name'),
+            'description'      => $request->input('description'),
+            'version'          => $request->input('version', 'v1.0'),
+            'status'           => $request->input('status', 'draft'),
+            'department_id'    => $request->input('department_id'),
+            'jobrole'          => $request->input('jobrole'),
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'created_framework',
+            'Created framework "' . $request->input('name') . '"',
+            'framework',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Framework created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $existing = DB::table('s_competency_frameworks')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Framework not found'], 404);
+        }
+
+        DB::table('s_competency_frameworks')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_framework',
+            'Deleted framework "' . $existing->name . '"',
+            'framework',
+            (int) $id,
+            $existing->name
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Framework deleted successfully']);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Show one framework with its competency items.
+     * ----------------------------------------------------------------- */
+    public function show(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $framework = DB::table('s_competency_frameworks')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$framework) {
+            return response()->json(['status' => 0, 'message' => 'Framework not found'], 404);
+        }
+
+        $framework->items = $this->frameworkItems($context['sub_institute_id'], (int) $id);
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Framework fetched successfully',
+            'data'    => $framework,
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Update framework metadata.
+     * ----------------------------------------------------------------- */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $framework = DB::table('s_competency_frameworks')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$framework) {
+            return response()->json(['status' => 0, 'message' => 'Framework not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'          => 'required|string|max:191',
+            'description'   => 'nullable|string',
+            'version'       => 'nullable|string|max:30',
+            'status'        => 'nullable|in:draft,active,archived',
+            'department_id' => 'nullable|integer',
+            'jobrole'       => 'nullable|string|max:191',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = [
+            'name'          => $request->input('name'),
+            'description'   => $request->input('description'),
+            'version'       => $request->input('version', $framework->version),
+            'status'        => $request->input('status', $framework->status),
+            'department_id' => $request->input('department_id'),
+            'jobrole'       => $request->input('jobrole'),
+        ];
+
+        DB::table('s_competency_frameworks')->where('id', $id)->update($update + [
+            'updated_by'    => $context['user_id'],
+            'updated_at'    => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'updated_framework',
+            'Updated framework "' . $request->input('name') . '"',
+            'framework',
+            (int) $id,
+            $request->input('name'),
+            $this->diffChanges($framework, $update, [
+                'name'          => 'Framework Name',
+                'description'   => 'Description',
+                'version'       => 'Version',
+                'status'        => 'Status',
+                'department_id' => 'Department',
+                'jobrole'       => 'Job Role',
+            ])
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Framework updated successfully', 'data' => ['id' => (int) $id]]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Clone a framework (metadata + items) as a fresh draft.
+     * ----------------------------------------------------------------- */
+    public function clone(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $source = DB::table('s_competency_frameworks')
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$source) {
+            return response()->json(['status' => 0, 'message' => 'Framework not found'], 404);
+        }
+
+        $name = $request->input('name') ?: ($source->name . ' (Copy)');
+
+        $newId = DB::table('s_competency_frameworks')->insertGetId([
+            'sub_institute_id' => $sid,
+            'name'             => $name,
+            'description'      => $source->description,
+            'version'          => 'v1.0',
+            'status'           => 'draft',
+            'department_id'    => $source->department_id,
+            'jobrole'          => $source->jobrole,
+            'created_by'       => $context['user_id'],
+            'updated_by'       => $context['user_id'],
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $items = DB::table('s_competency_framework_items')
+            ->where('framework_id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->get();
+
+        foreach ($items as $item) {
+            DB::table('s_competency_framework_items')->insert([
+                'sub_institute_id'     => $sid,
+                'framework_id'         => $newId,
+                'competency_id'        => $item->competency_id,
+                'required_proficiency' => $item->required_proficiency,
+                'created_by'           => $context['user_id'],
+                'created_at'           => now(),
+                'updated_at'           => now(),
+            ]);
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'cloned_framework',
+            'Cloned framework "' . $source->name . '" as "' . $name . '"',
+            'framework',
+            (int) $newId,
+            $name
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Framework cloned successfully',
+            'data'    => ['id' => (int) $newId, 'name' => $name],
+        ], 201);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Framework items (competency -> required proficiency).
+     * ----------------------------------------------------------------- */
+    public function items(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Framework items fetched successfully',
+            'data'    => $this->frameworkItems($context['sub_institute_id'], (int) $id),
+        ]);
+    }
+
+    public function storeItem(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'competency_id'        => 'required|integer',
+            'required_proficiency' => 'nullable|string|max:50',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $framework = DB::table('s_competency_frameworks')
+            ->where('id', $id)->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+        if (!$framework) {
+            return response()->json(['status' => 0, 'message' => 'Framework not found'], 404);
+        }
+
+        $competencyId = (int) $request->input('competency_id');
+
+        $existing = DB::table('s_competency_framework_items')
+            ->where('framework_id', $id)
+            ->where('competency_id', $competencyId)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if ($existing) {
+            DB::table('s_competency_framework_items')->where('id', $existing->id)->update([
+                'required_proficiency' => $request->input('required_proficiency'),
+                'updated_at'           => now(),
+            ]);
+            $itemId = (int) $existing->id;
+        } else {
+            $itemId = DB::table('s_competency_framework_items')->insertGetId([
+                'sub_institute_id'     => $sid,
+                'framework_id'         => (int) $id,
+                'competency_id'        => $competencyId,
+                'required_proficiency' => $request->input('required_proficiency'),
+                'created_by'           => $context['user_id'],
+                'created_at'           => now(),
+                'updated_at'           => now(),
+            ]);
+        }
+
+        $competencyName = DB::table('s_users_skills')->where('id', $competencyId)->value('title');
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            $existing ? 'updated_framework_item' : 'added_framework_item',
+            ($existing ? 'Updated' : 'Added') . ' competency "' . ($competencyName ?: ('#' . $competencyId))
+                . '" in framework "' . $framework->name . '"',
+            'framework_item',
+            $itemId,
+            $competencyName ?: ('Competency #' . $competencyId),
+            $existing
+                ? $this->diffChanges(
+                    $existing,
+                    ['required_proficiency' => $request->input('required_proficiency')],
+                    ['required_proficiency' => 'Required Proficiency']
+                )
+                : null
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Framework item saved successfully',
+            'data'    => ['id' => $itemId],
+        ], 201);
+    }
+
+    public function destroyItem(Request $request, $id, $itemId)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $item = DB::table('s_competency_framework_items')
+            ->where('id', $itemId)
+            ->where('framework_id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$item) {
+            return response()->json(['status' => 0, 'message' => 'Framework item not found'], 404);
+        }
+
+        DB::table('s_competency_framework_items')->where('id', $itemId)->update([
+            'deleted_at' => now(),
+        ]);
+
+        $competencyName = DB::table('s_users_skills')->where('id', $item->competency_id)->value('title');
+        $frameworkName = DB::table('s_competency_frameworks')->where('id', $id)->value('name');
+
+        $this->logCompetencyActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_framework_item',
+            'Removed competency "' . ($competencyName ?: ('#' . $item->competency_id))
+                . '" from framework "' . ($frameworkName ?: ('#' . $id)) . '"',
+            'framework_item',
+            (int) $itemId,
+            $competencyName ?: ('Competency #' . $item->competency_id)
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Framework item removed successfully']);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Per-category weighting (s_competency_framework_weights).
+     * ----------------------------------------------------------------- */
+    public function weights(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        // All approved categories in the catalog, so every category can be weighted.
+        $categories = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->whereNotNull('category')
+            ->where('category', '!=', '')
+            ->select('category', DB::raw('COUNT(*) as c'))
+            ->groupBy('category')
+            ->orderByDesc('c')
+            ->pluck('category')
+            ->all();
+
+        $saved = DB::table('s_competency_framework_weights')
+            ->where('sub_institute_id', $sid)
+            ->where('framework_id', (int) $id)
+            ->whereNull('deleted_at')
+            ->pluck('weight', 'category')
+            ->all();
+
+        $rows = [];
+        foreach ($categories as $category) {
+            $rows[] = [
+                'category' => $category,
+                'weight'   => isset($saved[$category]) ? (float) $saved[$category] : 0.0,
+            ];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Weighting fetched successfully',
+            'data'    => $rows,
+        ]);
+    }
+
+    public function saveWeights(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'weights'            => 'required|array',
+            'weights.*.category' => 'required|string|max:191',
+            'weights.*.weight'   => 'required|numeric|min:0|max:100',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        // Each category that actually moved becomes one line of the audit
+        // entry's Change Summary, so a re-weighting reads as a single event.
+        $changes = [];
+
+        foreach ($request->input('weights') as $row) {
+            $category = $row['category'];
+            $weight = (float) $row['weight'];
+
+            $existing = DB::table('s_competency_framework_weights')
+                ->where('sub_institute_id', $sid)
+                ->where('framework_id', (int) $id)
+                ->where('category', $category)
+                ->whereNull('deleted_at')
+                ->first();
+
+            if ($existing) {
+                if ((float) $existing->weight !== $weight) {
+                    $changes[] = [
+                        'field' => 'weight:' . $category,
+                        'label' => $category . ' Weight',
+                        'old'   => $existing->weight . '%',
+                        'new'   => $weight . '%',
+                    ];
+                }
+
+                DB::table('s_competency_framework_weights')->where('id', $existing->id)->update([
+                    'weight'     => $weight,
+                    'updated_by' => $context['user_id'],
+                    'updated_at' => now(),
+                ]);
+            } else {
+                $changes[] = [
+                    'field' => 'weight:' . $category,
+                    'label' => $category . ' Weight',
+                    'old'   => null,
+                    'new'   => $weight . '%',
+                ];
+
+                DB::table('s_competency_framework_weights')->insert([
+                    'sub_institute_id' => $sid,
+                    'framework_id'     => (int) $id,
+                    'category'         => $category,
+                    'weight'           => $weight,
+                    'created_by'       => $context['user_id'],
+                    'updated_by'       => $context['user_id'],
+                    'created_at'       => now(),
+                    'updated_at'       => now(),
+                ]);
+            }
+        }
+
+        $frameworkName = DB::table('s_competency_frameworks')->where('id', $id)->value('name');
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_framework_weights',
+            'Updated category weighting for "' . ($frameworkName ?: ('framework #' . $id)) . '"',
+            'framework_weight',
+            (int) $id,
+            $frameworkName ?: ('Framework #' . $id),
+            $changes
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Weighting saved successfully']);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Shared: framework items joined to the skill catalog.
+     * ----------------------------------------------------------------- */
+    private function frameworkItems(int $sid, int $frameworkId): array
+    {
+        return DB::table('s_competency_framework_items as fi')
+            ->leftJoin('s_users_skills as s', 's.id', '=', 'fi.competency_id')
+            ->where('fi.framework_id', $frameworkId)
+            ->where('fi.sub_institute_id', $sid)
+            ->whereNull('fi.deleted_at')
+            ->orderBy('s.category')
+            ->orderBy('s.title')
+            ->get([
+                'fi.id',
+                'fi.competency_id',
+                'fi.required_proficiency',
+                's.title as competency_name',
+                's.category',
+                's.sub_category',
+                's.competency_type',
+            ])
+            ->map(fn ($r) => [
+                'id'                   => (int) $r->id,
+                'competency_id'        => (int) $r->competency_id,
+                'competency_name'      => $r->competency_name,
+                'category'             => $r->category,
+                'sub_category'         => $r->sub_category,
+                'competency_type'      => $r->competency_type,
+                'required_proficiency' => $r->required_proficiency,
+            ])
+            ->all();
+    }
+}

--- a/app/Http/Controllers/Api/Competency/LearningAssignmentController.php
+++ b/app/Http/Controllers/Api/Competency/LearningAssignmentController.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Learning assignments for the Development & Career Path Workspace
+ * ("Assign Learning" + the Learning Assignments tab + the Learning Assigned KPI).
+ *
+ * Reuses the existing `lms_assignments` table rather than adding a parallel
+ * competency-owned one: it already models manager-assigned learning
+ * (user_id, course_id, assignment_type, due_date, status, progress,
+ * assigned_by, approval workflow). Courses come from `sub_std_map`, the same
+ * catalog LmsCourseEnrollController joins against.
+ *
+ * Every row this controller writes is tagged source='competency', and every
+ * read filters on it, so LMS-owned assignments and competency-owned ones stay
+ * separate even though they share a table. `lms_course_enroll` is deliberately
+ * NOT used here - that table records a learner enrolling themselves, which is a
+ * different action from a manager assigning learning to close a competency gap.
+ */
+class LearningAssignmentController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    private const TABLE = 'lms_assignments';
+    private const SOURCE = 'competency';
+
+    private const STATUSES = ['Not Started', 'In Progress', 'Completed', 'Overdue'];
+    private const TYPES = ['Mandatory', 'Optional', 'Recommended'];
+
+    /** GET /competency/learning-assignments */
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 15), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $query = DB::table(self::TABLE . ' as a')
+            ->leftJoin('sub_std_map as c', 'c.id', '=', 'a.course_id')
+            ->where('a.sub_institute_id', $sid)
+            ->where('a.source', self::SOURCE)
+            ->whereNull('a.deleted_at');
+
+        if ($status = $this->activeFilter($request->input('status'))) {
+            $query->where('a.status', $status);
+        }
+        if ($type = $this->activeFilter($request->input('assignment_type'))) {
+            $query->where('a.assignment_type', $type);
+        }
+        if ($planId = $this->activeFilter($request->input('development_plan_id'))) {
+            $query->where('a.development_plan_id', $planId);
+        }
+        if ($employeeId = $this->activeFilter($request->input('employee_id'))) {
+            $query->where('a.user_id', $employeeId);
+        }
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('c.display_name', 'like', "%{$search}%");
+        }
+
+        $total = (clone $query)->count();
+
+        $rows = $query->orderByDesc('a.id')->forPage($page, $perPage)
+            ->get([
+                'a.*',
+                'c.display_name as course_name',
+                'c.subject_type as course_type',
+                'c.subject_category as course_category',
+            ]);
+
+        $users = $this->userMap(
+            $rows->pluck('user_id')->merge($rows->pluck('assigned_by_id'))->filter()->all()
+        );
+
+        $planTitles = [];
+        $planIds = $rows->pluck('development_plan_id')->filter()->unique()->all();
+        if ($planIds) {
+            $planTitles = DB::table('s_competency_development_plans')
+                ->where('sub_institute_id', $sid)->whereIn('id', $planIds)
+                ->pluck('title', 'id')->all();
+        }
+
+        $competencyNames = [];
+        $competencyIds = $rows->pluck('competency_id')->filter()->unique()->all();
+        if ($competencyIds) {
+            $competencyNames = DB::table('s_users_skills')
+                ->whereIn('id', $competencyIds)->pluck('title', 'id')->all();
+        }
+
+        $data = $rows->map(function ($r) use ($users, $planTitles, $competencyNames) {
+            $employee = $r->user_id ? ($users[$r->user_id] ?? null) : null;
+
+            return [
+                'id'                  => (int) $r->id,
+                'user_id'             => (int) $r->user_id,
+                'employee_name'       => $employee['name'] ?? null,
+                'employee_initials'   => $employee['initials'] ?? null,
+                'course_id'           => (int) $r->course_id,
+                'course_name'         => $r->course_name,
+                'course_type'         => $r->course_type,
+                'course_category'     => $r->course_category,
+                'assignment_type'     => $r->assignment_type,
+                'status'              => $r->status,
+                'progress'            => (int) $r->progress,
+                'approval_status'     => $r->approval_status,
+                'due_date'            => $r->due_date,
+                'due_date_label'      => $r->due_date ? date('d M Y', strtotime($r->due_date)) : null,
+                'assigned_by'         => $r->assigned_by ?: (($r->assigned_by_id ?? null) ? ($users[$r->assigned_by_id]['name'] ?? null) : null),
+                'assigned_on'         => $r->assigned_on ? date('d M Y', strtotime($r->assigned_on)) : null,
+                'development_plan_id' => $r->development_plan_id ? (int) $r->development_plan_id : null,
+                'plan_title'          => $r->development_plan_id ? ($planTitles[$r->development_plan_id] ?? null) : null,
+                'competency_id'       => $r->competency_id ? (int) $r->competency_id : null,
+                'competency_name'     => $r->competency_id ? ($competencyNames[$r->competency_id] ?? null) : null,
+            ];
+        })->all();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Learning assignments fetched successfully',
+            'data'       => $data,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /**
+     * POST /competency/learning-assignments
+     * Accepts either user_ids[] (bulk assign one course to several employees)
+     * or a single employee_id.
+     */
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'course_id'           => 'required|integer|exists:sub_std_map,id',
+            'employee_id'         => 'required_without:user_ids|integer',
+            'user_ids'            => 'required_without:employee_id|array|min:1',
+            'user_ids.*'          => 'integer',
+            'assignment_type'     => 'nullable|in:' . implode(',', self::TYPES),
+            'status'              => 'nullable|in:' . implode(',', self::STATUSES),
+            'due_date'            => 'nullable|date',
+            'development_plan_id' => 'nullable|integer',
+            'competency_id'       => 'nullable|integer',
+            'progress'            => 'nullable|integer|min:0|max:100',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $targets = $request->input('user_ids') ?: [$request->input('employee_id')];
+        $targets = array_values(array_unique(array_filter(array_map('intval', (array) $targets))));
+
+        if (!$targets) {
+            return response()->json(['status' => 0, 'message' => 'Select at least one employee'], 422);
+        }
+
+        $actor = $context['user_id'] ? $this->userMap([$context['user_id']]) : [];
+        $actorName = $actor[$context['user_id']]['name'] ?? null;
+
+        $courseName = DB::table('sub_std_map')->where('id', $request->input('course_id'))->value('display_name');
+
+        $rows = [];
+        foreach ($targets as $userId) {
+            $rows[] = [
+                'sub_institute_id'    => $sid,
+                'user_id'             => $userId,
+                'course_id'           => (int) $request->input('course_id'),
+                'assignment_type'     => $request->input('assignment_type', 'Mandatory'),
+                'status'              => $request->input('status', 'Not Started'),
+                'progress'            => (int) $request->input('progress', 0),
+                'approval_status'     => 'approved',
+                'due_date'            => $request->input('due_date'),
+                'assigned_by'         => $actorName,
+                'assigned_by_id'      => $context['user_id'],
+                'assigned_on'         => now(),
+                'development_plan_id' => $request->input('development_plan_id'),
+                'competency_id'       => $request->input('competency_id'),
+                'source'              => self::SOURCE,
+                'created_at'          => now(),
+                'updated_at'          => now(),
+            ];
+        }
+
+        DB::table(self::TABLE)->insert($rows);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'assigned_learning',
+            'Assigned "' . ($courseName ?: 'course') . '" to ' . count($rows) . ' employee(s)',
+            // Assigning through a plan logs against the plan, so the plan's own
+            // "Notes & History" tab picks it up.
+            $request->input('development_plan_id') ? 'development_plan' : 'learning_assignment',
+            $request->input('development_plan_id') ? (int) $request->input('development_plan_id') : null,
+            $courseName ?: 'Course'
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => count($rows) === 1
+                ? 'Learning assigned successfully'
+                : 'Learning assigned to ' . count($rows) . ' employees',
+            'data'    => ['assigned' => count($rows)],
+        ], 201);
+    }
+
+    /** PUT /competency/learning-assignments/{id} */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->find($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Learning assignment not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'assignment_type'     => 'nullable|in:' . implode(',', self::TYPES),
+            'status'              => 'nullable|in:' . implode(',', self::STATUSES),
+            'progress'            => 'nullable|integer|min:0|max:100',
+            'due_date'            => 'nullable|date',
+            'development_plan_id' => 'nullable|integer',
+            'competency_id'       => 'nullable|integer',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = ['updated_at' => now()];
+        foreach (['assignment_type', 'due_date', 'development_plan_id', 'competency_id'] as $field) {
+            if ($request->has($field)) {
+                $update[$field] = $request->input($field);
+            }
+        }
+        if ($request->has('progress')) {
+            $update['progress'] = (int) $request->input('progress');
+        }
+        if ($request->has('status')) {
+            $update['status'] = $request->input('status');
+            if ($request->input('status') === 'Completed') {
+                $update['progress'] = 100;
+            }
+        }
+
+        DB::table(self::TABLE)->where('id', $row->id)->update($update);
+
+        $courseName = DB::table('sub_std_map')->where('id', $row->course_id)->value('display_name');
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            ($request->input('status') === 'Completed' && $row->status !== 'Completed')
+                ? 'completed_learning'
+                : 'updated_learning',
+            ($request->input('status') === 'Completed' && $row->status !== 'Completed' ? 'Completed' : 'Updated')
+                . ' learning assignment "' . ($courseName ?: 'course') . '"',
+            'learning_assignment',
+            (int) $row->id,
+            $courseName ?: ('Assignment #' . $row->id),
+            $this->diffChanges($row, $update, [
+                'assignment_type'     => 'Assignment Type',
+                'status'              => 'Status',
+                'progress'            => 'Progress',
+                'due_date'            => 'Due Date',
+                'development_plan_id' => 'Development Plan',
+                'competency_id'       => 'Linked Competency',
+            ])
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Learning assignment updated successfully',
+            'data'    => ['id' => (int) $row->id],
+        ]);
+    }
+
+    /** DELETE /competency/learning-assignments/{id} */
+    public function destroy(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $row = $this->find($id, $sid);
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Learning assignment not found'], 404);
+        }
+
+        DB::table(self::TABLE)->where('id', $row->id)->update(['deleted_at' => now(), 'updated_at' => now()]);
+
+        $courseName = DB::table('sub_std_map')->where('id', $row->course_id)->value('display_name');
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'unassigned_learning',
+            'Removed learning assignment "' . ($courseName ?: 'course') . '"',
+            'learning_assignment',
+            (int) $row->id,
+            $courseName ?: ('Assignment #' . $row->id)
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Learning assignment removed successfully']);
+    }
+
+    /**
+     * GET /competency/learning-assignments/courses
+     * The course picker for "Assign Learning" - the tenant's active catalog.
+     */
+    public function courses(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $query = DB::table('sub_std_map')
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->where('status', 1)
+            ->whereNotNull('display_name')
+            ->where('display_name', '!=', '');
+
+        if ($search = $this->activeFilter($request->input('search'))) {
+            $query->where('display_name', 'like', "%{$search}%");
+        }
+
+        $data = $query->orderBy('display_name')->limit(300)
+            ->get(['id', 'display_name', 'subject_type', 'subject_category'])
+            ->map(fn ($c) => [
+                'id'       => (int) $c->id,
+                'name'     => $c->display_name,
+                'type'     => $c->subject_type,
+                'category' => $c->subject_category,
+            ])->all();
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Courses fetched successfully',
+            'data'    => $data,
+        ]);
+    }
+
+    private function find($id, int $sid)
+    {
+        return DB::table(self::TABLE)
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->where('source', self::SOURCE)
+            ->whereNull('deleted_at')
+            ->first();
+    }
+
+    /** @return array<int, array{name:string, initials:string}> */
+    private function userMap(array $ids): array
+    {
+        $ids = array_values(array_filter(array_unique($ids)));
+        if (!$ids) {
+            return [];
+        }
+
+        return DB::table('tbluser')
+            ->whereIn('id', $ids)
+            ->get(['id', 'first_name', 'last_name'])
+            ->mapWithKeys(function ($u) {
+                $first = trim((string) $u->first_name);
+                $last = trim((string) $u->last_name);
+                $name = trim($first . ' ' . $last) ?: ('User ' . $u->id);
+                $initials = strtoupper(substr($first ?: $name, 0, 1) . substr($last, 0, 1));
+
+                return [(int) $u->id => ['name' => $name, 'initials' => $initials ?: strtoupper(substr($name, 0, 2))]];
+            })
+            ->all();
+    }
+}

--- a/app/Http/Controllers/Api/Competency/MappingReviewController.php
+++ b/app/Http/Controllers/Api/Competency/MappingReviewController.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Role-mapping change approvals (Workflow & Review tab). Backs the
+ * pending/approved/rejected queue on s_competency_mapping_reviews — a genuinely
+ * new concept (no backing table or API existed in the current backend or the
+ * old frontend, where mapping edits saved directly with no approval gate).
+ */
+class MappingReviewController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    public function index(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 30), 1), 100);
+        $page = max((int) $request->input('page', 1), 1);
+        $status = $this->activeFilter($request->input('status')) ?? 'pending';
+
+        $base = DB::table('s_competency_mapping_reviews')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        // Tab counts (independent of the current filter).
+        $counts = [
+            'pending'  => (clone $base)->where('status', 'pending')->count(),
+            'approved' => (clone $base)->where('status', 'approved')->count(),
+            'rejected' => (clone $base)->where('status', 'rejected')->count(),
+        ];
+
+        $query = (clone $base)->where('status', $status);
+        $total = (clone $query)->count();
+        $rows = $query->orderByDesc('id')->forPage($page, $perPage)->get();
+
+        $data = $rows->map(fn ($r) => [
+            'id'                => (int) $r->id,
+            'jobrole'           => $r->jobrole,
+            'department'        => $r->department,
+            'framework_id'      => $r->framework_id ? (int) $r->framework_id : null,
+            'submitted_by_name' => $r->submitted_by_name,
+            'status'            => $r->status,
+            'changes_count'     => (int) $r->changes_count,
+            'changes'           => $r->changes,
+            'note'              => $r->note,
+            'submitted_at'      => $r->created_at ? Carbon::parse($r->created_at)->format('M j, Y') : null,
+            'reviewed_at'       => $r->reviewed_at ? Carbon::parse($r->reviewed_at)->format('M j, Y') : null,
+        ])->all();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Mapping reviews fetched successfully',
+            'data'       => $data,
+            'counts'     => $counts,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'jobrole'       => 'required|string|max:191',
+            'department'    => 'nullable|string|max:191',
+            'department_id' => 'nullable|integer',
+            'framework_id'  => 'nullable|integer',
+            'changes_count' => 'nullable|integer|min:0',
+            'changes'       => 'nullable|string',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        // Resolve the submitter's display name for the queue card.
+        $submitterName = null;
+        if ($context['user_id']) {
+            $user = DB::table('tbluser')->where('id', $context['user_id'])->first();
+            if ($user) {
+                $submitterName = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));
+                $submitterName = $submitterName !== '' ? $submitterName : ($user->user_name ?? null);
+            }
+        }
+
+        $id = DB::table('s_competency_mapping_reviews')->insertGetId([
+            'sub_institute_id'  => $sid,
+            'jobrole'           => $request->input('jobrole'),
+            'department'        => $request->input('department'),
+            'department_id'     => $request->input('department_id'),
+            'framework_id'      => $request->input('framework_id'),
+            'submitted_by'      => $context['user_id'],
+            'submitted_by_name' => $submitterName,
+            'status'            => 'pending',
+            'changes_count'     => (int) $request->input('changes_count', 0),
+            'changes'           => $request->input('changes'),
+            'created_by'        => $context['user_id'],
+            'updated_by'        => $context['user_id'],
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'submitted_mapping_review',
+            'Submitted role mapping for "' . $request->input('jobrole') . '" for review',
+            'mapping_review',
+            $id,
+            $request->input('jobrole')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Mapping submitted for review',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    /** Approve or reject one review. */
+    public function update(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'action' => 'required|in:approve,reject',
+            'note'   => 'nullable|string',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $review = DB::table('s_competency_mapping_reviews')
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+        if (!$review) {
+            return response()->json(['status' => 0, 'message' => 'Review not found'], 404);
+        }
+
+        $status = $request->input('action') === 'approve' ? 'approved' : 'rejected';
+
+        DB::table('s_competency_mapping_reviews')->where('id', $id)->update([
+            'status'      => $status,
+            'note'        => $request->input('note'),
+            'reviewer_id' => $context['user_id'],
+            'reviewed_at' => now(),
+            'updated_by'  => $context['user_id'],
+            'updated_at'  => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            $status . '_mapping_review',
+            ucfirst($status) . ' role mapping for "' . $review->jobrole . '"',
+            'mapping_review',
+            (int) $id,
+            $review->jobrole,
+            $this->diffChanges($review, ['status' => $status], ['status' => 'Review Status'])
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Review ' . $status . ' successfully']);
+    }
+
+    /** Approve many at once (explicit ids, or all pending when none given). */
+    public function bulkApprove(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $query = DB::table('s_competency_mapping_reviews')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('status', 'pending');
+
+        $ids = $request->input('ids');
+        if (is_array($ids) && !empty($ids)) {
+            $ids = array_values(array_filter(array_map('intval', $ids)));
+            $query->whereIn('id', empty($ids) ? [0] : $ids);
+        }
+
+        // Capture the roles before the update so the audit entry can name them.
+        $roles = (clone $query)->limit(20)->pluck('jobrole')->all();
+
+        $affected = $query->update([
+            'status'      => 'approved',
+            'reviewer_id' => $context['user_id'],
+            'reviewed_at' => now(),
+            'updated_by'  => $context['user_id'],
+            'updated_at'  => now(),
+        ]);
+
+        if ($affected > 0) {
+            $this->logCompetencyActivity(
+                $sid,
+                $context['user_id'],
+                'bulk_approved_mapping_reviews',
+                'Approved ' . $affected . ' role mapping review' . ($affected === 1 ? '' : 's')
+                    . ($roles ? ' (' . implode(', ', array_slice($roles, 0, 3))
+                        . (count($roles) > 3 ? ', ...' : '') . ')' : ''),
+                'mapping_review',
+                null,
+                $affected === 1 && $roles ? $roles[0] : ($affected . ' reviews')
+            );
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => $affected . ' review(s) approved',
+            'data'    => ['approved' => $affected],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Competency/RoleMappingController.php
+++ b/app/Http/Controllers/Api/Competency/RoleMappingController.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * The Role Mapping Matrix: competencies (rows) x job roles (columns), each cell
+ * carrying the required proficiency level for that (competency, role) pair.
+ *
+ * Cells live in the existing tenant-scoped s_user_skill_jobrole table
+ * (jobrole, skill, proficiency_level) — the same table the old frontend wrote
+ * required proficiency to and that the command-center analytics count as
+ * "roles mapped". There is no clean JSON CRUD for a single cell today (the only
+ * existing writer is session-guarded, array-payloaded and coupled to a skill
+ * upsert), so these additive endpoints provide it without touching that writer.
+ */
+class RoleMappingController extends Controller
+{
+    use ResolvesCompetencyContext;
+
+    /* ----------------------------------------------------------------- *
+     * Column source: job roles ranked by how many skills they have mapped.
+     * ----------------------------------------------------------------- */
+    public function roles(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $perPage = min(max((int) $request->input('per_page', 8), 1), 50);
+        $page = max((int) $request->input('page', 1), 1);
+        $search = $this->activeFilter($request->input('search'));
+        $category = $this->activeFilter($request->input('category'));
+
+        $query = DB::table('s_user_skill_jobrole as m')
+            ->where('m.sub_institute_id', $sid)
+            ->whereNull('m.deleted_at')
+            ->whereNotNull('m.jobrole')
+            ->where('m.jobrole', '!=', '');
+
+        // Rank only by mappings whose skill is in the chosen category.
+        if ($category !== null) {
+            $titles = $this->categorySkillTitles($sid, $category);
+            $query->whereIn('m.skill', empty($titles) ? ['\0__none__'] : $titles);
+        }
+        if ($search !== null) {
+            $query->where('m.jobrole', 'like', "%{$search}%");
+        }
+
+        $grouped = $query
+            ->select('m.jobrole', DB::raw('COUNT(DISTINCT m.skill) as mapped_count'))
+            ->groupBy('m.jobrole')
+            ->orderByDesc('mapped_count')
+            ->orderBy('m.jobrole');
+
+        $all = $grouped->get();
+        $total = $all->count();
+        $rows = $all->forPage($page, $perPage)->values();
+
+        // Attach a department label per role (best-effort, from s_user_jobrole).
+        $roleNames = $rows->pluck('jobrole')->all();
+        $departments = [];
+        if (!empty($roleNames)) {
+            $departments = DB::table('s_user_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->whereNull('deleted_at')
+                ->whereIn('jobrole', $roleNames)
+                ->select('jobrole', 'department')
+                ->get()
+                ->keyBy('jobrole');
+        }
+
+        $data = $rows->map(fn ($r) => [
+            'jobrole'      => $r->jobrole,
+            'department'   => $departments[$r->jobrole]->department ?? null,
+            'mapped_count' => (int) $r->mapped_count,
+        ])->all();
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Job roles fetched successfully',
+            'data'       => $data,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / $perPage), 1),
+            ],
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * The matrix for one category across a set of selected roles.
+     * ----------------------------------------------------------------- */
+    public function matrix(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $category = $this->activeFilter($request->input('category'));
+        $roles = $this->rolesInput($request->input('jobroles'));
+
+        // Rows: competencies in the selected category (fallback: all approved).
+        $compQuery = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved');
+        if ($category !== null) {
+            $compQuery->where('category', $category);
+        }
+        $competencies = $compQuery
+            ->orderBy('title')
+            ->limit(300)
+            ->get(['id', 'title', 'description', 'category', 'sub_category', 'competency_type', 'proficiency_level'])
+            ->map(fn ($c) => [
+                'id'              => (int) $c->id,
+                'title'           => $c->title,
+                'description'     => $c->description,
+                'category'        => $c->category,
+                'sub_category'    => $c->sub_category,
+                'competency_type' => $c->competency_type,
+                'proficiency_level' => $c->proficiency_level,
+            ])
+            ->values();
+
+        $titles = $competencies->pluck('title')->all();
+
+        // Cells: existing mappings for these (role, skill) pairs.
+        $cells = [];
+        if (!empty($roles) && !empty($titles)) {
+            $rows = DB::table('s_user_skill_jobrole')
+                ->where('sub_institute_id', $sid)
+                ->whereNull('deleted_at')
+                ->whereIn('jobrole', $roles)
+                ->whereIn('skill', $titles)
+                ->get(['id', 'jobrole', 'skill', 'proficiency_level']);
+
+            foreach ($rows as $row) {
+                // Last write wins if duplicates exist for the same pair.
+                $cells[$row->jobrole][$row->skill] = [
+                    'id'    => (int) $row->id,
+                    'level' => $this->normalizeLevel($row->proficiency_level),
+                    'raw'   => $row->proficiency_level,
+                ];
+            }
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Matrix fetched successfully',
+            'data'    => [
+                'category'     => $category,
+                'roles'        => array_values($roles),
+                'competencies' => $competencies,
+                'cells'        => $cells,
+            ],
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Set / update one cell's required proficiency.
+     * ----------------------------------------------------------------- */
+    public function upsertCell(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'jobrole'           => 'required|string|max:191',
+            'skill'             => 'required_without:competency_id|string|max:191',
+            'competency_id'     => 'required_without:skill|integer',
+            'proficiency_level' => 'required|string|max:20',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $jobrole = $request->input('jobrole');
+        $skill = $this->resolveSkillTitle($sid, $request->input('skill'), $request->input('competency_id'));
+        if ($skill === null) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+        $level = (string) $request->input('proficiency_level');
+
+        $existing = DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->where('jobrole', $jobrole)
+            ->where('skill', $skill)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if ($existing) {
+            DB::table('s_user_skill_jobrole')->where('id', $existing->id)->update([
+                'proficiency_level' => $level,
+                'updated_by'        => $context['user_id'],
+                'updated_at'        => now(),
+            ]);
+            $id = (int) $existing->id;
+        } else {
+            // Carry over the skill's catalog metadata where available.
+            $skillRow = DB::table('s_users_skills')
+                ->where('sub_institute_id', $sid)
+                ->where('title', $skill)
+                ->whereNull('deleted_at')
+                ->first();
+
+            $id = DB::table('s_user_skill_jobrole')->insertGetId([
+                'jobrole'           => $jobrole,
+                'skill'             => $skill,
+                'type'              => 'S',
+                'proficiency_level' => $level,
+                'skill_code'        => $skillRow->skill_code ?? null,
+                'sub_institute_id'  => $sid,
+                'created_by'        => $context['user_id'],
+                'updated_by'        => $context['user_id'],
+                'created_at'        => now(),
+                'updated_at'        => now(),
+            ]);
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'mapped_role_competency',
+            'Set "' . $skill . '" to level ' . $level . ' for "' . $jobrole . '"',
+            'role_mapping',
+            $id,
+            $jobrole . ' - ' . $skill,
+            $existing
+                ? $this->diffChanges($existing, ['proficiency_level' => $level], ['proficiency_level' => 'Required Proficiency'])
+                : null
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Mapping saved successfully',
+            'data'    => ['id' => $id, 'jobrole' => $jobrole, 'skill' => $skill, 'proficiency_level' => $level],
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Clear a cell (soft delete the mapping row).
+     * ----------------------------------------------------------------- */
+    public function deleteCell(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'jobrole'       => 'required|string|max:191',
+            'skill'         => 'required_without:competency_id|string|max:191',
+            'competency_id' => 'required_without:skill|integer',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $jobrole = $request->input('jobrole');
+        $skill = $this->resolveSkillTitle($sid, $request->input('skill'), $request->input('competency_id'));
+        if ($skill === null) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        $affected = DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->where('jobrole', $jobrole)
+            ->where('skill', $skill)
+            ->whereNull('deleted_at')
+            ->update([
+                'deleted_at' => now(),
+                'deleted_by' => $context['user_id'],
+            ]);
+
+        if ($affected === 0) {
+            return response()->json(['status' => 0, 'message' => 'Mapping not found'], 404);
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'unmapped_role_competency',
+            'Cleared "' . $skill . '" from "' . $jobrole . '"',
+            'role_mapping',
+            null,
+            $jobrole . ' - ' . $skill
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Mapping cleared successfully']);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Helpers
+     * ----------------------------------------------------------------- */
+
+    /** Distinct skill titles belonging to a category (for scoping). */
+    private function categorySkillTitles(int $sid, string $category): array
+    {
+        return DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->where('category', $category)
+            ->distinct()
+            ->pluck('title')
+            ->all();
+    }
+
+    /** Normalise a mixed proficiency value ("4", "Advanced") to an int 1..6 or null. */
+    private function normalizeLevel($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+        $map = [
+            'awareness' => 1, 'basic' => 2, 'foundational' => 2, 'working knowledge' => 2,
+            'intermediate' => 3, 'applied' => 3, 'applied expertise' => 3,
+            'advanced' => 4, 'advanced practice' => 4,
+            'expert' => 5, 'strategic' => 5, 'strategic leadership' => 5,
+        ];
+        return $map[strtolower(trim((string) $value))] ?? null;
+    }
+
+    /** Resolve the canonical skill title from an explicit title or a competency_id. */
+    private function resolveSkillTitle(int $sid, $skill, $competencyId): ?string
+    {
+        if (is_string($skill) && trim($skill) !== '') {
+            return trim($skill);
+        }
+        if (is_numeric($competencyId)) {
+            $row = DB::table('s_users_skills')
+                ->where('sub_institute_id', $sid)
+                ->where('id', (int) $competencyId)
+                ->whereNull('deleted_at')
+                ->first();
+            return $row->title ?? null;
+        }
+        return null;
+    }
+
+    /** Accept jobroles as an array or comma-separated string; drop blanks. */
+    private function rolesInput($input): array
+    {
+        if (is_array($input)) {
+            $roles = $input;
+        } elseif (is_string($input) && $input !== '') {
+            $roles = explode(',', $input);
+        } else {
+            return [];
+        }
+
+        return collect($roles)
+            ->map(fn ($r) => trim((string) $r))
+            ->filter(fn ($r) => $r !== '' && $r !== 'all')
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Controllers/Api/Competency/StudioController.php
+++ b/app/Http/Controllers/Api/Competency/StudioController.php
@@ -1,0 +1,702 @@
+<?php
+
+namespace App\Http\Controllers\Api\Competency;
+
+use App\Http\Controllers\Api\Competency\Concerns\ManagesCompetencySettings;
+use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Read models for the Framework & Role Mapping Studio that don't belong to a
+ * single CRUD resource: the five summary cards, the Framework Structure
+ * category tree, and the Proficiency Scale (+ KASA behavioural indicators).
+ *
+ * Everything here reads EXISTING tables:
+ *   - competencies / categories -> s_users_skills
+ *   - job roles                 -> s_user_jobrole
+ *   - role mapping coverage      -> s_user_skill_jobrole (tenant) vs s_jobrole_skills (master baseline)
+ *   - proficiency scale          -> s_proficiency_levels (+ s_proficiency_{knowledge,ability,attitude,behaviour})
+ *   - frameworks                 -> s_competency_frameworks
+ */
+class StudioController extends Controller
+{
+    use ResolvesCompetencyContext;
+    use ManagesCompetencySettings;
+
+    /**
+     * The "Weighting Configuration" panel's scoring rules, with the defaults a
+     * tenant that has never saved them gets. Keys are the allowed set: anything
+     * else in the request body is ignored.
+     */
+    private const WEIGHTING_DEFAULTS = [
+        // weighted | simple - how a competency score rolls up across categories
+        'scoring_model'     => 'weighted',
+        // none | half | whole - rounding applied to the rolled-up score
+        'rounding'          => 'half',
+        // the score a role is expected to reach, as a percentage
+        'target_threshold'  => 80,
+        // zero | exclude - how a competency with no mapping counts
+        'unmapped_handling' => 'exclude',
+        // which surfaces the category weights are applied to
+        'apply_to'          => ['assessments', 'gap_analysis'],
+    ];
+
+    private const SCORING_MODELS = ['weighted', 'simple'];
+    private const ROUNDING_MODES = ['none', 'half', 'whole'];
+    private const UNMAPPED_MODES = ['zero', 'exclude'];
+    private const APPLY_TARGETS = ['assessments', 'gap_analysis', 'role_readiness', 'development_plans'];
+
+    /* ----------------------------------------------------------------- *
+     * Weighting Configuration (scoring rules behind the category weights)
+     * ----------------------------------------------------------------- */
+
+    /** GET /competency/studio/weighting-config */
+    public function weightingConfig(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Weighting configuration fetched successfully',
+            'data'    => [
+                'settings' => $this->competencySettings(
+                    $context['sub_institute_id'],
+                    'weighting',
+                    self::WEIGHTING_DEFAULTS
+                ),
+                'options'  => [
+                    'scoring_model'     => [
+                        ['value' => 'weighted', 'label' => 'Weighted average', 'hint' => 'Each category contributes in proportion to its weight.'],
+                        ['value' => 'simple',   'label' => 'Simple average',   'hint' => 'Every competency counts equally; weights are ignored.'],
+                    ],
+                    'rounding'          => [
+                        ['value' => 'none',  'label' => 'No rounding'],
+                        ['value' => 'half',  'label' => 'Nearest 0.5'],
+                        ['value' => 'whole', 'label' => 'Nearest whole level'],
+                    ],
+                    'unmapped_handling' => [
+                        ['value' => 'exclude', 'label' => 'Excluded', 'hint' => 'Competencies with no mapping are left out of the score.'],
+                        ['value' => 'zero',    'label' => 'Counted as zero', 'hint' => 'An unmapped competency drags the score down.'],
+                    ],
+                    'apply_to'          => [
+                        ['value' => 'assessments',       'label' => 'Assessment scoring'],
+                        ['value' => 'gap_analysis',      'label' => 'Gap analysis'],
+                        ['value' => 'role_readiness',    'label' => 'Role readiness / % match'],
+                        ['value' => 'development_plans', 'label' => 'Development plan priorities'],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /** PUT /competency/studio/weighting-config */
+    public function saveWeightingConfig(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'scoring_model'     => 'sometimes|required|in:' . implode(',', self::SCORING_MODELS),
+            'rounding'          => 'sometimes|required|in:' . implode(',', self::ROUNDING_MODES),
+            'target_threshold'  => 'sometimes|required|integer|min:0|max:100',
+            'unmapped_handling' => 'sometimes|required|in:' . implode(',', self::UNMAPPED_MODES),
+            'apply_to'          => 'sometimes|array',
+            'apply_to.*'        => 'in:' . implode(',', self::APPLY_TARGETS),
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $before = $this->competencySettings($sid, 'weighting', self::WEIGHTING_DEFAULTS);
+
+        $settings = $this->saveCompetencySettings(
+            $sid,
+            'weighting',
+            $request->all(),
+            self::WEIGHTING_DEFAULTS,
+            $context['user_id']
+        );
+
+        $labels = [
+            'scoring_model'     => 'Scoring Model',
+            'rounding'          => 'Rounding',
+            'target_threshold'  => 'Target Threshold',
+            'unmapped_handling' => 'Unmapped Competencies',
+            'apply_to'          => 'Applied To',
+        ];
+
+        $changes = [];
+        foreach ($labels as $key => $label) {
+            $old = is_array($before[$key]) ? implode(', ', $before[$key]) : $before[$key];
+            $new = is_array($settings[$key]) ? implode(', ', $settings[$key]) : $settings[$key];
+            if ((string) $old !== (string) $new) {
+                $changes[] = ['field' => $key, 'label' => $label, 'old' => $old, 'new' => $new];
+            }
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_weighting_config',
+            'Updated the competency scoring configuration',
+            'framework_weight',
+            null,
+            'Weighting Configuration',
+            $changes
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Weighting configuration saved successfully',
+            'data'    => ['settings' => $settings],
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Summary cards + mapping-coverage donut
+     * ----------------------------------------------------------------- */
+    public function summary(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        // Active framework (most recently touched 'active' one).
+        $activeFramework = DB::table('s_competency_frameworks')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('status', 'active')
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id')
+            ->first();
+
+        // Total published competencies == approved skills in the catalog.
+        $totalCompetencies = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->count();
+
+        // Roles + mapping coverage (distinct jobrole names, internally consistent).
+        $allRoles = DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereNotNull('jobrole')
+            ->where('jobrole', '!=', '')
+            ->distinct()
+            ->pluck('jobrole')
+            ->all();
+        $totalRoles = count($allRoles);
+
+        // Tenant per-role distinct skill counts (actual mapping).
+        $tenantCounts = DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereNotNull('jobrole')
+            ->select('jobrole', DB::raw('COUNT(DISTINCT skill) as c'))
+            ->groupBy('jobrole')
+            ->pluck('c', 'jobrole')
+            ->all();
+
+        // Master baseline distinct skill counts per role (recommended set).
+        $masterCounts = DB::table('s_jobrole_skills')
+            ->whereIn('jobrole', $totalRoles > 0 ? $allRoles : ['\0__none__'])
+            ->select('jobrole', DB::raw('COUNT(DISTINCT skill) as c'))
+            ->groupBy('jobrole')
+            ->pluck('c', 'jobrole')
+            ->all();
+
+        $fully = 0;
+        $partial = 0;
+        $notMapped = 0;
+        foreach ($allRoles as $role) {
+            $actual = (int) ($tenantCounts[$role] ?? 0);
+            $expected = (int) ($masterCounts[$role] ?? 0);
+
+            if ($actual === 0) {
+                $notMapped++;
+            } elseif ($expected > 0 && $actual < $expected) {
+                $partial++;
+            } else {
+                $fully++;
+            }
+        }
+        $rolesMapped = $fully + $partial;
+        $coverage = $totalRoles > 0 ? (int) round(($rolesMapped / $totalRoles) * 100) : 0;
+
+        $pct = fn ($n) => $totalRoles > 0 ? (int) round(($n / $totalRoles) * 100) : 0;
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Studio summary fetched successfully',
+            'data'    => [
+                'active_framework' => $activeFramework ? [
+                    'id'      => (int) $activeFramework->id,
+                    'name'    => $activeFramework->name,
+                    'status'  => $activeFramework->status,
+                    'version' => $activeFramework->version,
+                ] : null,
+                'total_competencies' => $totalCompetencies,
+                'roles_mapped'       => $rolesMapped,
+                'total_roles'        => $totalRoles,
+                'coverage_percent'   => $coverage,
+                // Last published: the active framework's timestamp, else the most
+                // recently touched framework of any status (so it's never blank
+                // when frameworks exist).
+                'last_published'     => $this->lastPublished($sid, $activeFramework),
+                'mapping_summary' => [
+                    'total_roles'     => $totalRoles,
+                    'fully_mapped'    => $fully,
+                    'partially_mapped'=> $partial,
+                    'not_mapped'      => $notMapped,
+                    'fully_pct'       => $pct($fully),
+                    'partial_pct'     => $pct($partial),
+                    'not_pct'         => $pct($notMapped),
+                ],
+            ],
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Framework Structure — category tree from the skill catalog
+     * ----------------------------------------------------------------- */
+    public function frameworkStructure(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $search = $this->activeFilter($request->input('search'));
+
+        $base = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->whereNotNull('category')
+            ->where('category', '!=', '');
+
+        // Category-level counts.
+        $categoryRows = (clone $base)
+            ->select('category', DB::raw('COUNT(*) as c'))
+            ->groupBy('category')
+            ->orderByDesc('c')
+            ->get();
+
+        // Sub-category counts, bucketed under their category.
+        $subRows = (clone $base)
+            ->whereNotNull('sub_category')
+            ->where('sub_category', '!=', '')
+            ->select('category', 'sub_category', DB::raw('COUNT(*) as c'))
+            ->groupBy('category', 'sub_category')
+            ->orderBy('category')
+            ->orderByDesc('c')
+            ->get();
+
+        $childrenByCategory = [];
+        foreach ($subRows as $r) {
+            $childrenByCategory[$r->category][] = [
+                'name'  => $r->sub_category,
+                'count' => (int) $r->c,
+            ];
+        }
+
+        $tree = [];
+        $index = 0;
+        foreach ($categoryRows as $r) {
+            if ($search && stripos($r->category, $search) === false) {
+                // Keep the category if a child matches the search.
+                $childMatch = collect($childrenByCategory[$r->category] ?? [])
+                    ->contains(fn ($c) => stripos($c['name'], $search) !== false);
+                if (!$childMatch) {
+                    continue;
+                }
+            }
+            $index++;
+            $tree[] = [
+                'index'    => $index,
+                'category' => $r->category,
+                'count'    => (int) $r->c,
+                'children' => $childrenByCategory[$r->category] ?? [],
+            ];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Framework structure fetched successfully',
+            'data'    => $tree,
+        ]);
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Proficiency scale + KASA behavioural indicators
+     * ----------------------------------------------------------------- */
+    public function proficiencyScale(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        // Tenant-global scale (skill_id NULL). Fall back to any tenant rows.
+        $levelQuery = DB::table('s_proficiency_levels')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        $levels = (clone $levelQuery)->whereNull('skill_id')
+            ->orderByRaw('CAST(proficiency_type AS UNSIGNED)')
+            ->get();
+
+        if ($levels->isEmpty()) {
+            $levels = $levelQuery->orderByRaw('CAST(proficiency_type AS UNSIGNED)')->get();
+        }
+
+        $scale = $levels->map(fn ($row) => [
+            'id'          => (int) $row->id,
+            'level'       => (int) $row->proficiency_type,
+            'label'       => $row->proficiency_level,      // "Level 3"
+            'name'        => $row->type_description,        // "Applied Expertise"
+            'description' => $row->description,
+        ])->values()->all();
+
+        // KASA descriptors (one small read per dimension).
+        $kasa = [];
+        foreach ([
+            'knowledge' => 's_proficiency_knowledge',
+            'ability'   => 's_proficiency_ability',
+            'attitude'  => 's_proficiency_attitude',
+            'behaviour' => 's_proficiency_behaviour',
+        ] as $key => $table) {
+            $rows = DB::table($table)
+                ->where('sub_institute_id', $sid)
+                ->orderByRaw('CAST(level AS UNSIGNED)')
+                ->get(['level', 'descriptor', 'indicators']);
+
+            $kasa[$key] = $rows->map(fn ($r) => [
+                'level'      => (int) $r->level,
+                'descriptor' => $r->descriptor,
+                'indicators' => $r->indicators,
+            ])->values()->all();
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Proficiency scale fetched successfully',
+            'data'    => [
+                'levels' => $scale,
+                'kasa'   => $kasa,
+            ],
+        ]);
+    }
+
+    /** Add a level to the tenant-global proficiency scale. */
+    public function storeLevel(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'name'        => 'required|string|max:191',
+            'description' => 'nullable|string',
+            'level'       => 'nullable|integer|min:1|max:20',
+        ]);
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first(), 'errors' => $validator->errors()], 422);
+        }
+
+        $next = $request->input('level');
+        if (!$next) {
+            $max = DB::table('s_proficiency_levels')
+                ->where('sub_institute_id', $sid)
+                ->whereNull('skill_id')
+                ->whereNull('deleted_at')
+                ->max(DB::raw('CAST(proficiency_type AS UNSIGNED)'));
+            $next = (int) $max + 1;
+        }
+
+        $id = DB::table('s_proficiency_levels')->insertGetId([
+            'skill_id'          => null,
+            'proficiency_level' => 'Level ' . $next,
+            'proficiency_type'  => (string) $next,
+            'type_description'  => $request->input('name'),
+            'description'       => $request->input('description'),
+            'sub_institute_id'  => $sid,
+            'created_by'        => $context['user_id'],
+            'updated_by'        => $context['user_id'],
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'created_proficiency_level',
+            'Added proficiency level ' . $next . ' "' . $request->input('name') . '"',
+            'proficiency_level',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Level added successfully', 'data' => ['id' => $id]], 201);
+    }
+
+    /** Edit a proficiency level's name / description / label. */
+    public function updateLevel(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'name'        => 'required|string|max:191',
+            'description' => 'nullable|string',
+            'label'       => 'nullable|string|max:191',
+        ]);
+        if ($validator->fails()) {
+            return response()->json(['status' => 0, 'message' => $validator->errors()->first(), 'errors' => $validator->errors()], 422);
+        }
+
+        $existing = DB::table('s_proficiency_levels')
+            ->where('id', $id)->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Level not found'], 404);
+        }
+
+        $update = [
+            'type_description' => $request->input('name'),
+            'description'      => $request->input('description'),
+        ];
+        if ($request->filled('label')) {
+            $update['proficiency_level'] = $request->input('label');
+        }
+
+        DB::table('s_proficiency_levels')->where('id', $id)->update($update + [
+            'updated_by'       => $context['user_id'],
+            'updated_at'       => now(),
+        ]);
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_proficiency_level',
+            'Updated proficiency level "' . $request->input('name') . '"',
+            'proficiency_level',
+            (int) $id,
+            $request->input('name'),
+            $this->diffChanges($existing, $update, [
+                'type_description'  => 'Level Name',
+                'description'       => 'Description',
+                'proficiency_level' => 'Level Label',
+            ])
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Level updated successfully']);
+    }
+
+    /** Soft-delete a proficiency level. */
+    public function deleteLevel(Request $request, $id)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $existing = DB::table('s_proficiency_levels')
+            ->where('id', $id)->where('sub_institute_id', $sid)->whereNull('deleted_at')->first();
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Level not found'], 404);
+        }
+
+        DB::table('s_proficiency_levels')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $levelName = $existing->type_description ?: $existing->proficiency_level;
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'deleted_proficiency_level',
+            'Deleted proficiency level "' . $levelName . '"',
+            'proficiency_level',
+            (int) $id,
+            $levelName
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Level deleted successfully']);
+    }
+
+    /** Formatted last-published date: active framework, else latest of any status. */
+    private function lastPublished(int $sid, $activeFramework): ?string
+    {
+        $latest = $activeFramework ?: DB::table('s_competency_frameworks')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id')
+            ->first();
+
+        return $latest && $latest->updated_at
+            ? Carbon::parse($latest->updated_at)->format('M j, Y')
+            : null;
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Default category weighting profile (framework_id = null).
+     * The Weighting & Configuration tab edits this tenant-wide profile;
+     * per-framework overrides live on FrameworkController::weights.
+     * ----------------------------------------------------------------- */
+    public function weights(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $categories = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->whereNotNull('category')
+            ->where('category', '!=', '')
+            ->select('category', DB::raw('COUNT(*) as c'))
+            ->groupBy('category')
+            ->orderByDesc('c')
+            ->pluck('category')
+            ->all();
+
+        $saved = DB::table('s_competency_framework_weights')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('framework_id')
+            ->whereNull('deleted_at')
+            ->pluck('weight', 'category')
+            ->all();
+
+        $rows = [];
+        foreach ($categories as $category) {
+            $rows[] = [
+                'category' => $category,
+                'weight'   => isset($saved[$category]) ? (float) $saved[$category] : 0.0,
+            ];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Weighting fetched successfully',
+            'data'    => $rows,
+        ]);
+    }
+
+    public function saveWeights(Request $request)
+    {
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $validator = Validator::make($request->all(), [
+            'weights'            => 'required|array',
+            'weights.*.category' => 'required|string|max:191',
+            'weights.*.weight'   => 'required|numeric|min:0|max:100',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        // Each category that actually moved becomes one line of the audit
+        // entry's Change Summary, so a re-weighting reads as a single event.
+        $changes = [];
+
+        foreach ($request->input('weights') as $row) {
+            $category = $row['category'];
+            $weight = (float) $row['weight'];
+
+            $existing = DB::table('s_competency_framework_weights')
+                ->where('sub_institute_id', $sid)
+                ->whereNull('framework_id')
+                ->where('category', $category)
+                ->whereNull('deleted_at')
+                ->first();
+
+            if ($existing) {
+                if ((float) $existing->weight !== $weight) {
+                    $changes[] = [
+                        'field' => 'weight:' . $category,
+                        'label' => $category . ' Weight',
+                        'old'   => $existing->weight . '%',
+                        'new'   => $weight . '%',
+                    ];
+                }
+
+                DB::table('s_competency_framework_weights')->where('id', $existing->id)->update([
+                    'weight'     => $weight,
+                    'updated_by' => $context['user_id'],
+                    'updated_at' => now(),
+                ]);
+            } else {
+                $changes[] = [
+                    'field' => 'weight:' . $category,
+                    'label' => $category . ' Weight',
+                    'old'   => null,
+                    'new'   => $weight . '%',
+                ];
+
+                DB::table('s_competency_framework_weights')->insert([
+                    'sub_institute_id' => $sid,
+                    'framework_id'     => null,
+                    'category'         => $category,
+                    'weight'           => $weight,
+                    'created_by'       => $context['user_id'],
+                    'updated_by'       => $context['user_id'],
+                    'created_at'       => now(),
+                    'updated_at'       => now(),
+                ]);
+            }
+        }
+
+        $this->logCompetencyActivity(
+            $sid,
+            $context['user_id'],
+            'updated_framework_weights',
+            'Updated the tenant default competency weighting profile',
+            'framework_weight',
+            null,
+            'Default Weighting Profile',
+            $changes
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Weighting saved successfully']);
+    }
+}

--- a/app/Http/Controllers/libraries/skillLibraryController.php
+++ b/app/Http/Controllers/libraries/skillLibraryController.php
@@ -1624,4 +1624,945 @@ class skillLibraryController extends Controller
         }
         return is_mobile($type, 'skill_library.index', $res, 'redirect');
     }
+
+    /* ================================================================
+     | Competency Library JSON API (additive)
+     |
+     | Backs the new Next.js "Competency Management -> Competency Library"
+     | screen. A competency IS an approved skill in this ERP, so these
+     | actions read/write the same s_users_skills catalog this controller
+     | already manages, but expose a clean, paginated JSON contract
+     | (no Blade view, no formType branching) that the new frontend's
+     | apiClient/withLaravelParams pattern consumes. They are wired to
+     | dedicated /api/skill_library/competency* routes registered BEFORE
+     | the resource route, so the existing resource endpoints and their
+     | consumers (old frontend, chatbot) are left completely untouched.
+     ================================================================ */
+
+    /**
+     * Token + tenant resolution shared by the competency-library actions.
+     * Same Sanctum personal-access-token check the rest of this controller
+     * uses, but always returns JSON (never a Blade redirect).
+     *
+     * @return array{sub_institute_id:int, user_id:?int}|\Illuminate\Http\JsonResponse
+     */
+    private function competencyLibraryContext(Request $request)
+    {
+        $token = $request->input('token');
+        if (!$token) {
+            return response()->json(['status' => 0, 'message' => 'Token not provided'], 401);
+        }
+        if (!PersonalAccessToken::findToken($token)) {
+            return response()->json(['status' => 0, 'message' => 'Invalid token'], 401);
+        }
+
+        $subInstituteId = $request->input('sub_institute_id') ?? $request->header('sub_institute_id');
+        if (!$subInstituteId || !is_numeric($subInstituteId)) {
+            return response()->json(['status' => 0, 'message' => 'sub_institute_id is required'], 400);
+        }
+
+        return [
+            'sub_institute_id' => (int) $subInstituteId,
+            'user_id'          => is_numeric($request->input('user_id')) ? (int) $request->input('user_id') : null,
+        ];
+    }
+
+    /**
+     * Append a row to the competency activity feed (s_competency_activity_log).
+     *
+     * This controller is not part of Api\Competency so it cannot use the shared
+     * ResolvesCompetencyContext trait, but the Competency Library screen it
+     * serves is a competency module screen: without this, creating, editing or
+     * deleting a competency here left no trace in the Audit & Activity Center
+     * while the same operations through Api\Competency\CompetencyController did.
+     * Same columns, same shape as the trait writes.
+     *
+     * @param array<int, array{field:string, label:string, old:mixed, new:mixed}>|null $changes
+     */
+    private function logCompetencyLibraryActivity(
+        int $subInstituteId,
+        ?int $userId,
+        string $action,
+        string $description,
+        ?int $subjectId,
+        ?string $subjectName,
+        ?array $changes = null
+    ): void {
+        $actorName = null;
+
+        if ($userId) {
+            $user = DB::table('tbluser')->where('id', $userId)->first();
+            if ($user) {
+                $actorName = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));
+                $actorName = $actorName !== '' ? $actorName : ($user->user_name ?? null);
+            }
+        }
+
+        DB::table('s_competency_activity_log')->insert([
+            'sub_institute_id' => $subInstituteId,
+            'user_id'          => $userId,
+            'actor_name'       => $actorName,
+            'action'           => $action,
+            'description'      => $description,
+            'subject_type'     => 'competency',
+            'subject_id'       => $subjectId,
+            'subject_name'     => $subjectName !== null ? mb_substr($subjectName, 0, 191) : null,
+            'changes'          => ($changes !== null && $changes !== []) ? json_encode(array_values($changes)) : null,
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+    }
+
+    /**
+     * Field-level diff for the Audit Center's Change Summary: only the columns
+     * in $labels that are present in $after and actually differ.
+     *
+     * @param  object|array<string, mixed> $before
+     * @param  array<string, mixed>        $after
+     * @param  array<string, string>       $labels
+     * @return array<int, array{field:string, label:string, old:mixed, new:mixed}>
+     */
+    private function competencyLibraryDiff($before, array $after, array $labels): array
+    {
+        $before = is_object($before) ? (array) $before : $before;
+        $changes = [];
+
+        foreach ($after as $column => $newValue) {
+            if (!array_key_exists($column, $labels)) {
+                continue;
+            }
+
+            $oldValue = $before[$column] ?? null;
+
+            if ((string) ($oldValue ?? '') === (string) ($newValue ?? '')) {
+                continue;
+            }
+
+            $changes[] = [
+                'field' => $column,
+                'label' => $labels[$column],
+                'old'   => $oldValue,
+                'new'   => $newValue,
+            ];
+        }
+
+        return $changes;
+    }
+
+    /**
+     * The shared filter chain behind the competency list and its export, so the
+     * "Export Library" button always exports exactly what the table is showing.
+     * Aliased `s` because callers join tbluser as `u` for the owner name.
+     */
+    private function competencyLibraryQuery(Request $request, int $sid)
+    {
+        $query = DB::table('s_users_skills as s')
+            ->where('s.sub_institute_id', $sid)
+            ->whereNull('s.deleted_at');
+
+        if ($search = $this->competencyLibraryFilter($request->input('search'))) {
+            $query->where(function ($q) use ($search) {
+                $q->where('s.title', 'like', "%{$search}%")
+                    ->orWhere('s.description', 'like', "%{$search}%")
+                    ->orWhere('s.category', 'like', "%{$search}%");
+            });
+        }
+        if ($category = $this->competencyLibraryFilter($request->input('category'))) {
+            $query->where('s.category', $category);
+        }
+        if ($type = $this->competencyLibraryFilter($request->input('competency_type'))) {
+            $query->where('s.competency_type', $type);
+        }
+        if ($status = $this->competencyLibraryFilter($request->input('status'))) {
+            $query->where('s.approve_status', $status);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Row shape shared by the competency list and export. A method rather than
+     * a const because the owner name is a DB::raw expression.
+     *
+     * @return array<int, mixed>
+     */
+    private function competencyLibraryColumns(): array
+    {
+        return [
+            's.id',
+            's.title as name',
+            's.description',
+            's.category',
+            's.sub_category',
+            's.competency_type',
+            's.proficiency_level',
+            's.department',
+            's.department_id',
+            's.status',
+            's.approve_status',
+            's.created_at',
+            's.updated_at',
+            's.created_by',
+            DB::raw("TRIM(CONCAT(COALESCE(u.first_name,''),' ',COALESCE(u.last_name,''))) as owner"),
+        ];
+    }
+
+    /** Column labels the Change Summary shows for a competency edit. */
+    private const COMPETENCY_CHANGE_LABELS = [
+        'title'             => 'Competency Name',
+        'description'       => 'Description',
+        'category'          => 'Category',
+        'sub_category'      => 'Sub Category',
+        'competency_type'   => 'Competency Type',
+        'proficiency_level' => 'Proficiency Level',
+        'department_id'     => 'Department',
+        'approve_status'    => 'Status',
+    ];
+
+    /** Treat '', '0' and 'all' (any case) as "no filter". */
+    private function competencyLibraryFilter($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        $value = trim((string) $value);
+        return ($value === '' || $value === '0' || strtolower($value) === 'all') ? null : $value;
+    }
+
+    /**
+     * Paginated competency list for the Competency Library table.
+     * Filters: search (title/description/category), category, competency_type,
+     * status (approve_status). Sortable + paginated. Joins tbluser for owner.
+     */
+    public function competencyLibraryIndex(Request $request)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $perPage = min(max((int) $request->input('per_page', 10), 1), 200);
+        $page = max((int) $request->input('page', 1), 1);
+
+        $allowedSorts = ['title', 'category', 'competency_type', 'approve_status', 'updated_at', 'created_at'];
+        $sort = in_array($request->input('sort'), $allowedSorts, true) ? $request->input('sort') : 'id';
+        $direction = strtolower((string) $request->input('direction')) === 'asc' ? 'asc' : 'desc';
+
+        $query = $this->competencyLibraryQuery($request, $context['sub_institute_id']);
+
+        $total = (clone $query)->count();
+
+        $rows = $query
+            ->leftJoin('tbluser as u', 'u.id', '=', 's.created_by')
+            ->orderBy('s.' . $sort, $direction)
+            ->forPage($page, $perPage)
+            ->get($this->competencyLibraryColumns());
+
+        return response()->json([
+            'status'     => 1,
+            'message'    => 'Competencies fetched successfully',
+            'data'       => $rows,
+            'pagination' => [
+                'page'      => $page,
+                'per_page'  => $perPage,
+                'total'     => $total,
+                'last_page' => (int) max(ceil($total / max($perPage, 1)), 1),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /skill_library/competency-export
+     *
+     * Every row matching the current filters, uncapped by the table's page size,
+     * for the "Export Library" action. The CSV itself is assembled client side so
+     * no new dependency is needed. Hard limit keeps a runaway export bounded.
+     */
+    public function competencyLibraryExport(Request $request)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $rows = $this->competencyLibraryQuery($request, $context['sub_institute_id'])
+            ->leftJoin('tbluser as u', 'u.id', '=', 's.created_by')
+            ->orderBy('s.title')
+            ->limit(5000)
+            ->get($this->competencyLibraryColumns());
+
+        $this->logCompetencyLibraryActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'exported_competencies',
+            'Exported ' . $rows->count() . ' ' . ($rows->count() === 1 ? 'competency' : 'competencies') . ' from the library',
+            null,
+            'Competency Library'
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competencies exported successfully',
+            'data'    => $rows,
+        ]);
+    }
+
+    /**
+     * POST /skill_library/competency-import
+     *
+     * Bulk-create competencies from a parsed spreadsheet ("Import Competencies").
+     * The file is parsed in the browser and posted as a plain rows array, so this
+     * needs no spreadsheet library on the server.
+     *
+     * A row whose title already exists for the tenant is SKIPPED rather than
+     * updated or duplicated - an import must never silently overwrite a curated
+     * competency. Per-row problems are reported back with their row number
+     * instead of failing the whole batch.
+     */
+    public function competencyLibraryImport(Request $request)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        // Structural validation only. A missing/blank name is a PER-ROW problem
+        // reported back in `details` - making it `required` here would fail the
+        // whole batch on one bad line, which is exactly what an import must not do.
+        $validator = Validator::make($request->all(), [
+            'rows'                     => 'required|array|min:1|max:2000',
+            'rows.*.name'              => 'nullable|string|max:191',
+            'rows.*.description'       => 'nullable|string',
+            'rows.*.category'          => 'nullable|string|max:191',
+            'rows.*.sub_category'      => 'nullable|string|max:191',
+            'rows.*.competency_type'   => 'nullable|string|max:50',
+            'rows.*.proficiency_level' => 'nullable|string|max:191',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        // One lookup for the whole batch rather than a query per row.
+        $existing = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->pluck('title')
+            ->map(fn ($title) => mb_strtolower(trim((string) $title)))
+            ->flip();
+
+        $insert = [];
+        $skipped = [];
+        $seen = [];
+        $now = now();
+
+        foreach ($request->input('rows') as $index => $row) {
+            $line = $index + 1;
+            $name = trim((string) ($row['name'] ?? ''));
+            $key = mb_strtolower($name);
+
+            if ($name === '') {
+                $skipped[] = ['row' => $line, 'name' => '', 'reason' => 'Missing competency name'];
+                continue;
+            }
+            if (isset($existing[$key])) {
+                $skipped[] = ['row' => $line, 'name' => $name, 'reason' => 'Already in the library'];
+                continue;
+            }
+            if (isset($seen[$key])) {
+                $skipped[] = ['row' => $line, 'name' => $name, 'reason' => 'Duplicated within the file'];
+                continue;
+            }
+            $seen[$key] = true;
+
+            $insert[] = [
+                'sub_institute_id'  => $sid,
+                'title'             => $name,
+                'description'       => $this->competencyLibraryFilter($row['description'] ?? null),
+                'category'          => $this->competencyLibraryFilter($row['category'] ?? null),
+                'sub_category'      => $this->competencyLibraryFilter($row['sub_category'] ?? null),
+                'competency_type'   => $this->competencyLibraryFilter($row['competency_type'] ?? null) ?: 'Skill',
+                'proficiency_level' => $this->competencyLibraryFilter($row['proficiency_level'] ?? null),
+                'status'            => 'Active',
+                'approve_status'    => 'Approved',
+                'created_by'        => $context['user_id'],
+                'updated_by'        => $context['user_id'],
+                'created_at'        => $now,
+                'updated_at'        => $now,
+            ];
+        }
+
+        if ($insert) {
+            foreach (array_chunk($insert, 500) as $chunk) {
+                DB::table('s_users_skills')->insert($chunk);
+            }
+
+            $this->logCompetencyLibraryActivity(
+                $sid,
+                $context['user_id'],
+                'imported_competencies',
+                'Imported ' . count($insert) . ' ' . (count($insert) === 1 ? 'competency' : 'competencies')
+                    . ($skipped ? ' (' . count($skipped) . ' skipped)' : ''),
+                null,
+                'Competency Library Import'
+            );
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => count($insert) . ' ' . (count($insert) === 1 ? 'competency' : 'competencies') . ' imported'
+                . ($skipped ? ', ' . count($skipped) . ' skipped' : ''),
+            'data'    => [
+                'imported' => count($insert),
+                'skipped'  => count($skipped),
+                'details'  => array_slice($skipped, 0, 100),
+            ],
+        ], 201);
+    }
+
+    /**
+     * POST /skill_library/competency/{id}/clone
+     *
+     * Duplicate a competency as a new library entry ("Clone Competency"). The
+     * copy is created as Pending so it has to be reviewed before it counts as an
+     * approved competency, and its name is made unique so the list never shows
+     * two identical titles.
+     *
+     * Associations are deliberately NOT copied: role mappings and framework
+     * membership are curation decisions about the original, and silently
+     * duplicating 50k mapping rows would be a destructive surprise.
+     */
+    public function competencyLibraryClone(Request $request, $id)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $source = DB::table('s_users_skills')
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$source) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        $requested = trim((string) $request->input('name', ''));
+        $base = $requested !== '' ? $requested : $source->title . ' (Copy)';
+        $name = $base;
+
+        // Only bump a suffix when the chosen name is genuinely taken.
+        for ($attempt = 2; $attempt <= 50; $attempt++) {
+            $taken = DB::table('s_users_skills')
+                ->where('sub_institute_id', $sid)
+                ->whereNull('deleted_at')
+                ->where('title', $name)
+                ->exists();
+            if (!$taken) {
+                break;
+            }
+            $name = $base . ' ' . $attempt;
+        }
+
+        $newId = DB::table('s_users_skills')->insertGetId([
+            'sub_institute_id'  => $sid,
+            'title'             => $name,
+            'description'       => $source->description,
+            'category'          => $source->category,
+            'sub_category'      => $source->sub_category,
+            'competency_type'   => $source->competency_type,
+            'proficiency_level' => $source->proficiency_level,
+            'department_id'     => $source->department_id,
+            'department'        => $source->department,
+            'status'            => 'Active',
+            'approve_status'    => 'Pending',
+            'created_by'        => $context['user_id'],
+            'updated_by'        => $context['user_id'],
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ]);
+
+        $this->logCompetencyLibraryActivity(
+            $sid,
+            $context['user_id'],
+            'cloned_competency',
+            'Cloned competency "' . $source->title . '" as "' . $name . '"',
+            $newId,
+            $name
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency cloned as "' . $name . '"',
+            'data'    => ['id' => $newId, 'name' => $name],
+        ], 201);
+    }
+
+    /**
+     * PUT /skill_library/competency/{id}/archive
+     *
+     * Archive (approve_status = Cancelled) or restore (Approved) a competency.
+     *
+     * Deliberately NOT a delete: a competency is referenced by role mappings,
+     * framework items, assessments, development plans and certifications, so
+     * removing the row would orphan all of them. Archiving takes it out of
+     * circulation while keeping every reference intact, and is reversible.
+     * The soft-delete endpoint is untouched and still available.
+     */
+    public function competencyLibraryArchive(Request $request, $id)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $existing = DB::table('s_users_skills')
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        $restore = filter_var($request->input('restore', false), FILTER_VALIDATE_BOOLEAN);
+        $status = $restore ? 'Approved' : 'Cancelled';
+
+        DB::table('s_users_skills')->where('id', $id)->update([
+            'approve_status' => $status,
+            'updated_by'     => $context['user_id'],
+            'updated_at'     => now(),
+        ]);
+
+        $this->logCompetencyLibraryActivity(
+            $sid,
+            $context['user_id'],
+            $restore ? 'restored_competency' : 'archived_competency',
+            ($restore ? 'Restored' : 'Archived') . ' competency "' . $existing->title . '"',
+            (int) $id,
+            $existing->title,
+            $this->competencyLibraryDiff(
+                $existing,
+                ['approve_status' => $status],
+                self::COMPETENCY_CHANGE_LABELS
+            )
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => $restore ? 'Competency restored successfully' : 'Competency archived successfully',
+            'data'    => ['id' => (int) $id, 'approve_status' => $status],
+        ]);
+    }
+
+    /** Single competency (for the details side panel / edit prefill). */
+    public function competencyLibraryShow(Request $request, $id)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $row = DB::table('s_users_skills as s')
+            ->leftJoin('tbluser as u', 'u.id', '=', 's.created_by')
+            ->where('s.id', $id)
+            ->where('s.sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('s.deleted_at')
+            ->first([
+                's.id',
+                's.title as name',
+                's.description',
+                's.category',
+                's.sub_category',
+                's.competency_type',
+                's.proficiency_level',
+                's.department',
+                's.department_id',
+                's.job_titles',
+                's.related_skills',
+                's.learning_resources',
+                's.status',
+                's.approve_status',
+                's.created_at',
+                's.updated_at',
+                DB::raw("TRIM(CONCAT(COALESCE(u.first_name,''),' ',COALESCE(u.last_name,''))) as owner"),
+            ]);
+
+        if (!$row) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency fetched successfully',
+            'data'    => $row,
+        ]);
+    }
+
+    /**
+     * Detail payload for the Competency Library side panel's Proficiency Levels,
+     * Associations, Attachments and History tabs. All read from existing tables:
+     *  - proficiency  -> s_proficiency_levels (per-skill if defined, else global)
+     *  - associations -> s_user_skill_jobrole (roles) + s_competency_framework_items (frameworks)
+     *  - attachments  -> the resource text fields on s_users_skills
+     *  - history      -> the skill's audit columns + s_competency_activity_log
+     */
+    public function competencyLibraryDetail(Request $request, $id)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+        $sid = $context['sub_institute_id'];
+
+        $skill = DB::table('s_users_skills')
+            ->where('id', $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$skill) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        // --- Proficiency levels: per-skill overrides, else the tenant scale ---
+        $levels = DB::table('s_proficiency_levels')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')->where('skill_id', $id)
+            ->orderByRaw('CAST(proficiency_type AS UNSIGNED)')->get();
+        $scope = 'competency';
+        if ($levels->isEmpty()) {
+            $levels = DB::table('s_proficiency_levels')
+                ->where('sub_institute_id', $sid)->whereNull('deleted_at')->whereNull('skill_id')
+                ->orderByRaw('CAST(proficiency_type AS UNSIGNED)')->get();
+            $scope = 'global';
+        }
+        $proficiency = [
+            'scale_label' => $skill->proficiency_level,
+            'scope'       => $scope,
+            'levels'      => $levels->map(fn ($l) => [
+                'level'       => (int) $l->proficiency_type,
+                'label'       => $l->proficiency_level,
+                'name'        => $l->type_description,
+                'description' => $l->description,
+            ])->values()->all(),
+        ];
+
+        // --- Associations: roles that require it + frameworks that include it ---
+        $roles = DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')->where('skill', $skill->title)
+            ->select('jobrole', DB::raw('MAX(proficiency_level) as proficiency_level'))
+            ->groupBy('jobrole')->orderBy('jobrole')->limit(300)->get()
+            ->map(fn ($r) => ['jobrole' => $r->jobrole, 'proficiency_level' => $r->proficiency_level])->all();
+
+        $frameworks = DB::table('s_competency_framework_items as fi')
+            ->join('s_competency_frameworks as f', 'f.id', '=', 'fi.framework_id')
+            ->where('fi.competency_id', $id)->where('fi.sub_institute_id', $sid)
+            ->whereNull('fi.deleted_at')->whereNull('f.deleted_at')
+            ->select('f.id', 'f.name', 'f.status', 'fi.required_proficiency')->orderBy('f.name')->get()
+            ->map(fn ($r) => [
+                'id'                   => (int) $r->id,
+                'name'                 => $r->name,
+                'status'               => $r->status,
+                'required_proficiency' => $r->required_proficiency,
+            ])->all();
+
+        $associations = [
+            'roles'           => $roles,
+            'frameworks'      => $frameworks,
+            'role_count'      => count($roles),
+            'framework_count' => count($frameworks),
+        ];
+
+        // --- Top associated roles: the roles that demand it most -------------
+        // Ranked by required proficiency, because headcount per role is not
+        // derivable here - tbluser.jobtitle_id is 0 for every user on this
+        // tenant, so there is no employee-to-role edge to count.
+        $departments = DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereIn('jobrole', array_column($roles, 'jobrole'))
+            ->pluck('department', 'jobrole');
+
+        $topRoles = $roles;
+        usort($topRoles, function ($a, $b) {
+            $levelA = is_numeric($a['proficiency_level']) ? (int) $a['proficiency_level'] : 0;
+            $levelB = is_numeric($b['proficiency_level']) ? (int) $b['proficiency_level'] : 0;
+
+            return $levelB <=> $levelA ?: strcmp((string) $a['jobrole'], (string) $b['jobrole']);
+        });
+
+        $topRoles = array_map(fn ($role) => [
+            'jobrole'           => $role['jobrole'],
+            'proficiency_level' => $role['proficiency_level'],
+            'department'        => $departments[$role['jobrole']] ?? null,
+        ], array_slice($topRoles, 0, 5));
+
+        // --- Summary: where this competency is actually in use ---------------
+        $countFor = fn (string $table) => DB::table($table)
+            ->where('sub_institute_id', $sid)
+            ->where('competency_id', $id)
+            ->whereNull('deleted_at')
+            ->count();
+
+        $summary = [
+            'description'      => $skill->description,
+            'category'         => $skill->category,
+            'sub_category'     => $skill->sub_category,
+            'competency_type'  => $skill->competency_type,
+            'status'           => $skill->approve_status,
+            'role_count'       => count($roles),
+            'framework_count'  => count($frameworks),
+            // Employees carrying a rating for this competency (s_skill_matrix
+            // has no tenant column, so it is scoped through the skill id).
+            'rated_employees'  => DB::table('s_skill_matrix')
+                ->where('skill_id', $id)
+                ->whereNull('deleted_at')
+                ->distinct()
+                ->count('user_id'),
+            'plan_count'       => $countFor('s_competency_development_plans'),
+            'certification_count' => $countFor('s_competency_certifications'),
+            // s_competency_assessments has no competency_id - it links to a
+            // framework - so this is assessments run against the frameworks
+            // that actually contain this competency. Zero when it belongs to
+            // no framework, which is the honest answer.
+            'assessment_count' => empty($frameworks) ? 0 : DB::table('s_competency_assessments')
+                ->where('sub_institute_id', $sid)
+                ->whereNull('deleted_at')
+                ->whereIn('framework_id', array_column($frameworks, 'id'))
+                ->count(),
+            'learning_count'   => DB::table('lms_assignments')
+                ->where('sub_institute_id', $sid)
+                ->where('source', 'competency')
+                ->where('competency_id', $id)
+                ->whereNull('deleted_at')
+                ->count(),
+            'evidence_count'   => $countFor('s_competency_evidence'),
+        ];
+
+        // --- Attachments: the skill's resource text fields ---
+        $attachments = [];
+        foreach ([
+            'Learning Resources'            => $skill->learning_resources ?? null,
+            'Certification / Qualifications' => $skill->certification_qualifications ?? null,
+            'SOP / Practice Link'           => $skill->sop_practice_link ?? null,
+            'Experience / Projects'         => $skill->experience_project ?? null,
+            'Assessment Method'             => $skill->assesment_method ?? null,
+        ] as $label => $value) {
+            if ($value !== null && trim((string) $value) !== '') {
+                $attachments[] = ['type' => $label, 'value' => trim((string) $value)];
+            }
+        }
+
+        // --- History: audit columns + activity-log entries for this competency ---
+        $resolveName = function ($uid) {
+            if (!$uid) {
+                return 'System';
+            }
+            $u = DB::table('tbluser')->where('id', $uid)->first();
+            if (!$u) {
+                return 'System';
+            }
+            $n = trim(($u->first_name ?? '') . ' ' . ($u->last_name ?? ''));
+            return $n !== '' ? $n : ($u->user_name ?? 'System');
+        };
+
+        $history = [];
+        if ($skill->created_at) {
+            $history[] = ['action' => 'Competency created', 'by' => $resolveName($skill->created_by), 'date' => date('d M Y', strtotime($skill->created_at))];
+        }
+        $history[] = ['action' => 'Status: ' . $skill->approve_status, 'by' => $resolveName($skill->updated_by ?: $skill->created_by), 'date' => $skill->updated_at ? date('d M Y', strtotime($skill->updated_at)) : ''];
+        if ($skill->updated_at && $skill->updated_at !== $skill->created_at) {
+            $history[] = ['action' => 'Last updated', 'by' => $resolveName($skill->updated_by), 'date' => date('d M Y', strtotime($skill->updated_at))];
+        }
+        $acts = DB::table('s_competency_activity_log')
+            ->where('sub_institute_id', $sid)->where('subject_type', 'competency')->where('subject_id', $id)
+            ->orderByDesc('created_at')->limit(20)->get();
+        foreach ($acts as $a) {
+            $history[] = ['action' => $a->description ?: $a->action, 'by' => $a->actor_name ?: 'System', 'date' => $a->created_at ? date('d M Y', strtotime($a->created_at)) : ''];
+        }
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency detail fetched successfully',
+            'data'    => [
+                'summary'      => $summary,
+                'top_roles'    => $topRoles,
+                'proficiency'  => $proficiency,
+                'associations' => $associations,
+                'attachments'  => $attachments,
+                'history'      => $history,
+            ],
+        ]);
+    }
+
+    /** Create a competency (an approved skill row on s_users_skills). */
+    public function competencyLibraryStore(Request $request)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'              => 'required|string|max:191',
+            'description'       => 'nullable|string',
+            'category'          => 'nullable|string|max:191',
+            'sub_category'      => 'nullable|string|max:191',
+            'competency_type'   => 'nullable|string|max:50',
+            'proficiency_level' => 'nullable|string|max:191',
+            'department_id'     => 'nullable|integer',
+            'status'            => 'nullable|in:Approved,Pending,Cancelled',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $id = DB::table('s_users_skills')->insertGetId([
+            'sub_institute_id'  => $context['sub_institute_id'],
+            'title'             => $request->input('name'),
+            'description'       => $request->input('description'),
+            'category'          => $request->input('category'),
+            'sub_category'      => $request->input('sub_category'),
+            'competency_type'   => $request->input('competency_type') ?: 'Skill',
+            'proficiency_level' => $request->input('proficiency_level'),
+            'department_id'     => $request->input('department_id'),
+            'status'            => 'Active',
+            'approve_status'    => $request->input('status', 'Approved'),
+            'created_by'        => $context['user_id'],
+            'updated_by'        => $context['user_id'],
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ]);
+
+        $this->logCompetencyLibraryActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'created_competency',
+            'Created competency "' . $request->input('name') . '"',
+            $id,
+            $request->input('name')
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency created successfully',
+            'data'    => ['id' => $id],
+        ], 201);
+    }
+
+    /** Update a competency's core fields. */
+    public function competencyLibraryUpdate(Request $request, $id)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $existing = DB::table('s_users_skills')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name'              => 'required|string|max:191',
+            'description'       => 'nullable|string',
+            'category'          => 'nullable|string|max:191',
+            'sub_category'      => 'nullable|string|max:191',
+            'competency_type'   => 'nullable|string|max:50',
+            'proficiency_level' => 'nullable|string|max:191',
+            'department_id'     => 'nullable|integer',
+            'status'            => 'nullable|in:Approved,Pending,Cancelled',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'status'  => 0,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors(),
+            ], 422);
+        }
+
+        $update = [
+            'title'             => $request->input('name'),
+            'description'       => $request->input('description'),
+            'category'          => $request->input('category'),
+            'sub_category'      => $request->input('sub_category'),
+            'competency_type'   => $request->input('competency_type') ?: 'Skill',
+            'proficiency_level' => $request->input('proficiency_level'),
+            'department_id'     => $request->input('department_id'),
+            'updated_by'        => $context['user_id'],
+            'updated_at'        => now(),
+        ];
+        if ($request->filled('status')) {
+            $update['approve_status'] = $request->input('status');
+        }
+
+        DB::table('s_users_skills')->where('id', $id)->update($update);
+
+        $this->logCompetencyLibraryActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'updated_competency',
+            'Updated competency "' . $request->input('name') . '"',
+            (int) $id,
+            $request->input('name'),
+            $this->competencyLibraryDiff($existing, $update, self::COMPETENCY_CHANGE_LABELS)
+        );
+
+        return response()->json([
+            'status'  => 1,
+            'message' => 'Competency updated successfully',
+            'data'    => ['id' => (int) $id],
+        ]);
+    }
+
+    /** Soft-delete a competency. */
+    public function competencyLibraryDestroy(Request $request, $id)
+    {
+        $context = $this->competencyLibraryContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $existing = DB::table('s_users_skills')
+            ->where('id', $id)
+            ->where('sub_institute_id', $context['sub_institute_id'])
+            ->whereNull('deleted_at')
+            ->first();
+        if (!$existing) {
+            return response()->json(['status' => 0, 'message' => 'Competency not found'], 404);
+        }
+
+        DB::table('s_users_skills')->where('id', $id)->update([
+            'deleted_at' => now(),
+            'deleted_by' => $context['user_id'],
+        ]);
+
+        $this->logCompetencyLibraryActivity(
+            $context['sub_institute_id'],
+            $context['user_id'],
+            'deleted_competency',
+            'Deleted competency "' . $existing->title . '"',
+            (int) $id,
+            $existing->title
+        );
+
+        return response()->json(['status' => 1, 'message' => 'Competency deleted successfully']);
+    }
 }

--- a/app/Models/Competency/CompetencyActivityLog.php
+++ b/app/Models/Competency/CompetencyActivityLog.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CompetencyActivityLog extends Model
+{
+    use HasFactory;
+
+    protected $table = 's_competency_activity_log';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'user_id' => 'integer',
+        'subject_id' => 'integer',
+        // [{field, label, old, new}, ...] - the Audit Center's Change Summary.
+        'changes' => 'array',
+    ];
+}

--- a/app/Models/Competency/CompetencyAssessment.php
+++ b/app/Models/Competency/CompetencyAssessment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyAssessment extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_assessments';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'framework_id' => 'integer',
+        'cycle_id' => 'integer',
+        'user_id' => 'integer',
+        'assessor_id' => 'integer',
+        'department_id' => 'integer',
+        'score' => 'float',
+        'due_date' => 'date',
+        'completed_at' => 'datetime',
+    ];
+}

--- a/app/Models/Competency/CompetencyAssessmentCycle.php
+++ b/app/Models/Competency/CompetencyAssessmentCycle.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyAssessmentCycle extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_assessment_cycles';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'start_date' => 'date',
+        'end_date' => 'date',
+    ];
+}

--- a/app/Models/Competency/CompetencyCareerPath.php
+++ b/app/Models/Competency/CompetencyCareerPath.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyCareerPath extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_career_paths';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'department_id' => 'integer',
+    ];
+
+    public function steps()
+    {
+        return $this->hasMany(CompetencyCareerPathStep::class, 'career_path_id')
+            ->orderBy('step_order');
+    }
+}

--- a/app/Models/Competency/CompetencyCareerPathStep.php
+++ b/app/Models/Competency/CompetencyCareerPathStep.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyCareerPathStep extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_career_path_steps';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'career_path_id' => 'integer',
+        'jobrole_id' => 'integer',
+        'step_order' => 'integer',
+    ];
+
+    public function path()
+    {
+        return $this->belongsTo(CompetencyCareerPath::class, 'career_path_id');
+    }
+}

--- a/app/Models/Competency/CompetencyCertification.php
+++ b/app/Models/Competency/CompetencyCertification.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyCertification extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_certifications';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'user_id' => 'integer',
+        'competency_id' => 'integer',
+        'department_id' => 'integer',
+        'issued_date' => 'date',
+        'expiry_date' => 'date',
+    ];
+}

--- a/app/Models/Competency/CompetencyCertificationRequirement.php
+++ b/app/Models/Competency/CompetencyCertificationRequirement.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyCertificationRequirement extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_certification_requirements';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id'      => 'integer',
+        'department_id'         => 'integer',
+        'competency_id'         => 'integer',
+        'is_mandatory'          => 'boolean',
+        'validity_months'       => 'integer',
+        'renewal_reminder_days' => 'integer',
+        'grace_period_days'     => 'integer',
+    ];
+}

--- a/app/Models/Competency/CompetencyDevelopmentPlan.php
+++ b/app/Models/Competency/CompetencyDevelopmentPlan.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyDevelopmentPlan extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_development_plans';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'user_id' => 'integer',
+        'competency_id' => 'integer',
+        'framework_id' => 'integer',
+        'department_id' => 'integer',
+        'progress' => 'integer',
+        'start_date' => 'date',
+        'due_date' => 'date',
+        'completed_at' => 'datetime',
+        'approver_id' => 'integer',
+        'mentor_id' => 'integer',
+    ];
+}

--- a/app/Models/Competency/CompetencyFramework.php
+++ b/app/Models/Competency/CompetencyFramework.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyFramework extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_frameworks';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'department_id' => 'integer',
+    ];
+
+    public function items()
+    {
+        return $this->hasMany(CompetencyFrameworkItem::class, 'framework_id');
+    }
+}

--- a/app/Models/Competency/CompetencyFrameworkItem.php
+++ b/app/Models/Competency/CompetencyFrameworkItem.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyFrameworkItem extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_framework_items';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'framework_id' => 'integer',
+        'competency_id' => 'integer',
+    ];
+}

--- a/app/Models/Competency/CompetencyFrameworkWeight.php
+++ b/app/Models/Competency/CompetencyFrameworkWeight.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyFrameworkWeight extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_framework_weights';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'framework_id' => 'integer',
+        'weight' => 'float',
+    ];
+}

--- a/app/Models/Competency/CompetencyMappingReview.php
+++ b/app/Models/Competency/CompetencyMappingReview.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyMappingReview extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_mapping_reviews';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'framework_id' => 'integer',
+        'department_id' => 'integer',
+        'submitted_by' => 'integer',
+        'reviewer_id' => 'integer',
+        'changes_count' => 'integer',
+        'reviewed_at' => 'datetime',
+    ];
+}

--- a/app/Models/Competency/CompetencyPlanAction.php
+++ b/app/Models/Competency/CompetencyPlanAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Competency;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CompetencyPlanAction extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 's_competency_plan_actions';
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'sub_institute_id' => 'integer',
+        'plan_id' => 'integer',
+        'competency_id' => 'integer',
+        'owner_id' => 'integer',
+        'due_date' => 'date',
+        'completed_at' => 'datetime',
+        'sequence' => 'integer',
+    ];
+
+    public function plan()
+    {
+        return $this->belongsTo(CompetencyDevelopmentPlan::class, 'plan_id');
+    }
+}

--- a/app/Services/Competency/CommandCenterService.php
+++ b/app/Services/Competency/CommandCenterService.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace App\Services\Competency;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Aggregates every metric the Competency Command Center dashboard renders:
+ * the six summary tiles, four progress rings, five work queues, the recent
+ * activity feed and the assessment-calendar bar.
+ *
+ * All queries are tenant scoped by sub_institute_id and honour the five
+ * command-center filters (Department, Job Role, Location, Business Unit,
+ * Job Family). The role-based filters are resolved against s_user_jobrole into
+ * a set of matching job roles, which then constrains every competency-domain
+ * table (they carry a `jobrole` column). Role coverage KPIs are computed
+ * directly from s_user_jobrole / s_user_skill_jobrole, exactly like the
+ * existing /api/competency/kpi endpoint.
+ */
+class CommandCenterService
+{
+    /** Build the full dashboard payload. */
+    public function dashboard(int $subInstituteId, ?int $userId, array $filters): array
+    {
+        [$totalRoles, $rolesWithSkills, $scopeRoles] = $this->resolveRoleScope($subInstituteId, $filters);
+
+        return [
+            'summary'             => $this->summary($subInstituteId, $filters, $scopeRoles, $totalRoles, $rolesWithSkills),
+            'progress'            => $this->progress($subInstituteId, $scopeRoles, $totalRoles, $rolesWithSkills),
+            'work_queues'         => $this->workQueues($subInstituteId, $userId, $scopeRoles),
+            'recent_activity'     => $this->recentActivity($subInstituteId),
+            'assessment_calendar' => $this->assessmentCalendar($subInstituteId, $scopeRoles),
+        ];
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Role scope + coverage KPIs (from the existing Skill/Role tables)
+     * ----------------------------------------------------------------- */
+
+    /**
+     * @return array{0:int,1:int,2:?array<int,string>} [totalRoles, rolesWithSkills, scopeRoles|null]
+     */
+    private function resolveRoleScope(int $subInstituteId, array $filters): array
+    {
+        $roleBase = DB::table('s_user_jobrole as jr')
+            ->where('jr.sub_institute_id', $subInstituteId)
+            ->whereNull('jr.deleted_at');
+
+        if ($filters['department_id'] !== null) {
+            $roleBase->where('jr.department_id', (int) $filters['department_id']);
+        }
+        if ($filters['jobrole'] !== null) {
+            $roleBase->where('jr.jobrole', $filters['jobrole']);
+        }
+        if ($filters['location'] !== null) {
+            $roleBase->where('jr.location', $filters['location']);
+        }
+        if ($filters['business_unit'] !== null) {
+            $roleBase->where('jr.industries', $filters['business_unit']);
+        }
+        if ($filters['job_family'] !== null) {
+            $roleBase->where('jr.jobrole_category', $filters['job_family']);
+        }
+
+        $totalRoles = (clone $roleBase)->count();
+
+        $rolesWithSkills = (clone $roleBase)
+            ->whereExists(function ($q) use ($subInstituteId) {
+                $q->select(DB::raw(1))
+                    ->from('s_user_skill_jobrole as sj')
+                    ->whereColumn('sj.jobrole', 'jr.jobrole')
+                    ->where('sj.sub_institute_id', $subInstituteId)
+                    ->whereNull('sj.deleted_at');
+            })
+            ->count();
+
+        $scopeActive = collect($filters)->contains(fn ($v) => $v !== null);
+        $scopeRoles = $scopeActive
+            ? (clone $roleBase)->distinct()->pluck('jr.jobrole')->filter()->values()->all()
+            : null;
+
+        return [$totalRoles, $rolesWithSkills, $scopeRoles];
+    }
+
+    /** Constrain a competency-domain query to the active role scope. */
+    private function applyScope($query, ?array $scopeRoles)
+    {
+        if ($scopeRoles !== null) {
+            // Empty scope => the filter matched no roles => return nothing.
+            $query->whereIn('jobrole', empty($scopeRoles) ? ['\0__none__'] : $scopeRoles);
+        }
+
+        return $query;
+    }
+
+    private function baseCount(string $table, int $subInstituteId, ?array $scopeRoles)
+    {
+        $q = DB::table($table)
+            ->where('sub_institute_id', $subInstituteId)
+            ->whereNull('deleted_at');
+
+        return $this->applyScope($q, $scopeRoles);
+    }
+
+    /**
+     * Total published competencies. In this ERP a competency IS an approved
+     * skill, so this reads the existing s_users_skills catalog rather than a
+     * duplicate competency table. Honours the same filters: Department maps to
+     * s_users_skills.department_id; the role-based filters restrict to the
+     * skills the in-scope job roles require (via s_jobrole_skills).
+     */
+    private function competenciesCount(int $sid, array $filters, ?array $scopeRoles): int
+    {
+        $q = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved');
+
+        if ($filters['department_id'] !== null) {
+            $q->where('department_id', (int) $filters['department_id']);
+        }
+
+        $roleFilterActive = $filters['jobrole'] !== null || $filters['location'] !== null
+            || $filters['business_unit'] !== null || $filters['job_family'] !== null;
+
+        if ($roleFilterActive) {
+            $roles = ($scopeRoles && count($scopeRoles)) ? $scopeRoles : ['\0__none__'];
+            $q->whereIn('title', function ($sub) use ($roles) {
+                $sub->select('skill')->distinct()->from('s_jobrole_skills')->whereIn('jobrole', $roles);
+            });
+        }
+
+        return $q->count();
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Summary tiles
+     * ----------------------------------------------------------------- */
+
+    private function summary(int $sid, array $filters, ?array $scopeRoles, int $totalRoles, int $rolesWithSkills): array
+    {
+        $competencies = $this->competenciesCount($sid, $filters, $scopeRoles);
+
+        $frameworks = (clone $this->baseCount('s_competency_frameworks', $sid, $scopeRoles))
+            ->where('status', 'active')->count();
+
+        $assessments = (clone $this->baseCount('s_competency_assessments', $sid, $scopeRoles))
+            ->whereIn('status', ['open', 'in_progress'])->count();
+
+        $certifications = (clone $this->baseCount('s_competency_certifications', $sid, $scopeRoles))
+            ->where('status', 'valid')->count();
+
+        $plans = (clone $this->baseCount('s_competency_development_plans', $sid, $scopeRoles))
+            ->where('status', 'active')->count();
+
+        return [
+            ['key' => 'competencies', 'label' => 'Total Competencies', 'value' => $competencies, 'desc' => 'Published'],
+            ['key' => 'frameworks', 'label' => 'Active Frameworks', 'value' => $frameworks, 'desc' => 'Active'],
+            ['key' => 'roles_mapped', 'label' => 'Job Roles Mapped', 'value' => $rolesWithSkills, 'total' => $totalRoles, 'desc' => 'Out of ' . $totalRoles],
+            ['key' => 'assessments', 'label' => 'Active Assessments', 'value' => $assessments, 'desc' => 'In progress'],
+            ['key' => 'certifications', 'label' => 'Certifications', 'value' => $certifications, 'desc' => 'Valid'],
+            ['key' => 'development_plans', 'label' => 'Development Plans', 'value' => $plans, 'desc' => 'Active'],
+        ];
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Progress rings
+     * ----------------------------------------------------------------- */
+
+    private function progress(int $sid, ?array $scopeRoles, int $totalRoles, int $rolesWithSkills): array
+    {
+        // Role mapping completion (from Skill/Role tables)
+        $rolePercent = $totalRoles > 0 ? round(($rolesWithSkills / $totalRoles) * 100) : 0;
+
+        // Assessment completion
+        $totalAssessments = (clone $this->baseCount('s_competency_assessments', $sid, $scopeRoles))->count();
+        $completedAssessments = (clone $this->baseCount('s_competency_assessments', $sid, $scopeRoles))
+            ->where('status', 'completed')->count();
+        $assessmentPercent = $totalAssessments > 0 ? round(($completedAssessments / $totalAssessments) * 100) : 0;
+
+        // Certification compliance: valid certifications / all still-relevant
+        // (non-revoked) certifications. Count-based so it stays meaningful
+        // regardless of how many distinct employee records the tenant holds.
+        $validCerts = (clone $this->baseCount('s_competency_certifications', $sid, $scopeRoles))
+            ->where('status', 'valid')->count();
+        $activeCerts = (clone $this->baseCount('s_competency_certifications', $sid, $scopeRoles))
+            ->where('status', '!=', 'revoked')->count();
+        $certPercent = $activeCerts > 0 ? round(($validCerts / $activeCerts) * 100) : 0;
+
+        // Development plan completion
+        $totalPlans = (clone $this->baseCount('s_competency_development_plans', $sid, $scopeRoles))->count();
+        $completedPlans = (clone $this->baseCount('s_competency_development_plans', $sid, $scopeRoles))
+            ->where('status', 'completed')->count();
+        $planPercent = $totalPlans > 0 ? round(($completedPlans / $totalPlans) * 100) : 0;
+
+        return [
+            ['key' => 'role_mapping', 'title' => 'Role Mapping Completion', 'percent' => (int) $rolePercent, 'current' => $rolesWithSkills, 'total' => $totalRoles, 'sub' => 'Roles Mapped'],
+            ['key' => 'assessment', 'title' => 'Assessment Completion', 'percent' => (int) $assessmentPercent, 'current' => $completedAssessments, 'total' => $totalAssessments, 'sub' => 'Completed Assessments'],
+            ['key' => 'certification', 'title' => 'Certification Compliance', 'percent' => (int) $certPercent, 'current' => $validCerts, 'total' => $activeCerts, 'sub' => 'Valid Certifications'],
+            ['key' => 'development', 'title' => 'Development Plan Completion', 'percent' => (int) $planPercent, 'current' => $completedPlans, 'total' => $totalPlans, 'sub' => 'Completed Plans'],
+        ];
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Work queues
+     * ----------------------------------------------------------------- */
+
+    private function workQueues(int $sid, ?int $userId, ?array $scopeRoles): array
+    {
+        $today = Carbon::today()->toDateString();
+        $in30Days = Carbon::today()->addDays(30)->toDateString();
+
+        // Pending my approvals: dev plans awaiting the current user's approval.
+        $myApprovals = 0;
+        if ($userId !== null) {
+            $myApprovals = (clone $this->baseCount('s_competency_development_plans', $sid, $scopeRoles))
+                ->where('approval_status', 'pending_approval')
+                ->where('approver_id', $userId)
+                ->count();
+        }
+
+        $pendingReviews = (clone $this->baseCount('s_competency_assessments', $sid, $scopeRoles))
+            ->where('review_status', 'pending_review')
+            ->count();
+
+        $openAssessments = (clone $this->baseCount('s_competency_assessments', $sid, $scopeRoles))
+            ->whereIn('status', ['open', 'in_progress'])
+            ->count();
+
+        $expiringCerts = (clone $this->baseCount('s_competency_certifications', $sid, $scopeRoles))
+            ->whereIn('status', ['valid', 'expiring'])
+            ->whereNotNull('expiry_date')
+            ->whereBetween('expiry_date', [$today, $in30Days])
+            ->count();
+
+        $overduePlans = (clone $this->baseCount('s_competency_development_plans', $sid, $scopeRoles))
+            ->where(function ($q) use ($today) {
+                $q->where('status', 'overdue')
+                    ->orWhere(function ($q2) use ($today) {
+                        $q2->whereNotNull('due_date')
+                            ->where('due_date', '<', $today)
+                            ->whereNotIn('status', ['completed']);
+                    });
+            })
+            ->count();
+
+        return [
+            ['key' => 'my_approvals', 'label' => 'Pending My Approvals', 'count' => $myApprovals],
+            ['key' => 'pending_reviews', 'label' => 'Pending Reviews', 'count' => $pendingReviews],
+            ['key' => 'open_assessments', 'label' => 'Open Assessments', 'count' => $openAssessments],
+            ['key' => 'expiring_certifications', 'label' => 'Expiring Certifications (30 Days)', 'count' => $expiringCerts],
+            ['key' => 'overdue_plans', 'label' => 'Overdue Development Plans', 'count' => $overduePlans],
+        ];
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Recent activity
+     * ----------------------------------------------------------------- */
+
+    private function recentActivity(int $sid, int $limit = 6): array
+    {
+        $rows = DB::table('s_competency_activity_log')
+            ->where('sub_institute_id', $sid)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+
+        return $rows->map(function ($row) {
+            $timestamp = $row->created_at;
+
+            return [
+                'id'        => (int) $row->id,
+                'user'      => $row->actor_name ?: 'System',
+                'action'    => $row->description ?: $row->action,
+                'time'      => $timestamp ? Carbon::parse($timestamp)->diffForHumans() : '',
+                'timestamp' => $timestamp,
+            ];
+        })->all();
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Assessment calendar
+     * ----------------------------------------------------------------- */
+
+    private function assessmentCalendar(int $sid, ?array $scopeRoles): array
+    {
+        $today = Carbon::today()->toDateString();
+        $in60Days = Carbon::today()->addDays(60)->toDateString();
+
+        // The active cycle, or the next one starting within 60 days.
+        $cycle = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where(function ($q) use ($today, $in60Days) {
+                $q->where(function ($q2) use ($today) {
+                    $q2->where('start_date', '<=', $today)->where('end_date', '>=', $today);
+                })->orWhereBetween('start_date', [$today, $in60Days]);
+            })
+            ->orderBy('start_date')
+            ->first();
+
+        $upcomingAssessments = (clone $this->baseCount('s_competency_assessments', $sid, $scopeRoles))
+            ->whereNotNull('due_date')
+            ->whereBetween('due_date', [$today, $in60Days])
+            ->count();
+
+        $cyclePayload = null;
+        if ($cycle) {
+            $start = $cycle->start_date ? Carbon::parse($cycle->start_date) : null;
+            $end = $cycle->end_date ? Carbon::parse($cycle->end_date) : null;
+            $rangeLabel = $start && $end
+                ? $start->format('M j') . ' - ' . $end->format('M j, Y')
+                : null;
+
+            $cyclePayload = [
+                'id'          => (int) $cycle->id,
+                'name'        => $cycle->name,
+                'status'      => $cycle->status,
+                'start_date'  => $cycle->start_date,
+                'end_date'    => $cycle->end_date,
+                'range_label' => $rangeLabel,
+            ];
+        }
+
+        return [
+            'cycle'          => $cyclePayload,
+            'upcoming_count' => $upcomingAssessments,
+        ];
+    }
+
+    /* ----------------------------------------------------------------- *
+     * Filter options (drives the five dropdowns)
+     * ----------------------------------------------------------------- */
+
+    public function filterOptions(int $sid): array
+    {
+        $roleBase = DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at');
+
+        $departments = (clone $roleBase)
+            ->whereNotNull('department_id')
+            ->where('department_id', '!=', 0)
+            ->select('department_id', 'department')
+            ->distinct()
+            ->orderBy('department')
+            ->get()
+            ->map(fn ($r) => ['value' => (string) $r->department_id, 'label' => $r->department ?: ('Department ' . $r->department_id)])
+            ->unique('value')
+            ->values()
+            ->all();
+
+        $simpleOptions = function ($column) use ($roleBase) {
+            return (clone $roleBase)
+                ->whereNotNull($column)
+                ->where($column, '!=', '')
+                ->select($column)
+                ->distinct()
+                ->orderBy($column)
+                ->pluck($column)
+                ->map(fn ($v) => ['value' => (string) $v, 'label' => (string) $v])
+                ->all();
+        };
+
+        return [
+            'departments'    => $departments,
+            'jobroles'       => $simpleOptions('jobrole'),
+            'locations'      => $simpleOptions('location'),
+            'business_units' => $simpleOptions('industries'),
+            'job_families'   => $simpleOptions('jobrole_category'),
+        ];
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -66,6 +66,11 @@ return [
             'endpoint' => env('DO_SPACES_ENDPOINT'),
             'region' => env('DO_SPACES_REGION'),
             'bucket' => env('DO_SPACES_BUCKET'),
+            // Public base URL, so Storage::disk('digitalocean')->url($path) can
+            // resolve a browsable link for API responses. Additive: no existing
+            // caller invokes ->url() on this disk (uploads are written with
+            // putFileAs/put and the Blade views hardcode the CDN host).
+            'url' => rtrim(env('DO_PATH', ''), '/') ?: null,
             'throw' => true,
             'verify' => false,
         ],

--- a/database/migrations/2026_07_28_100100_create_competency_module_tables.php
+++ b/database/migrations/2026_07_28_100100_create_competency_module_tables.php
@@ -1,0 +1,176 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Competency Management domain tables.
+ *
+ * Backs the Competency Command Center dashboard (and the sibling competency
+ * screens) with real, tenant-scoped data. Prior to this the whole module was a
+ * read-only analytics layer over the Skill / Job-Role / Task tables with no
+ * domain models of its own.
+ *
+ * Conventions mirror the 2026 HRMS/Leave migrations: bigIncrements PK,
+ * indexed unsignedBigInteger sub_institute_id, nullable indexed audit columns,
+ * timestamps + softDeletes, string-based status enums, and loose joins
+ * (jobrole string / department_id int) with NO foreign-key constraints — the
+ * same style s_user_jobrole / s_jobrole_skills already use.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // NB: "Competencies" are intentionally NOT a new table. In this ERP a
+        // competency IS an approved skill (existing s_users_skills catalog), and
+        // the competency analytics already treat skills as competencies. The
+        // command center reads/writes s_users_skills for the competency concept,
+        // so only the tables below (which have no existing equivalent) are new.
+
+        // 1. Competency frameworks -------------------------------------------
+        Schema::create('s_competency_frameworks', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('name', 191);
+            $table->text('description')->nullable();
+            $table->string('version', 30)->default('v1.0');
+            // draft | active | archived
+            $table->string('status', 30)->default('draft')->index();
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->string('jobrole', 191)->nullable();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 3. Framework -> competency mapping ---------------------------------
+        Schema::create('s_competency_framework_items', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->unsignedBigInteger('framework_id')->index();
+            $table->unsignedBigInteger('competency_id')->index();
+            $table->string('required_proficiency', 50)->nullable();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 4. Assessment cycles (drives the Assessment Calendar bar) ----------
+        Schema::create('s_competency_assessment_cycles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('name', 191);
+            $table->text('description')->nullable();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            // scheduled | active | closed
+            $table->string('status', 30)->default('scheduled')->index();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 5. Assessments ------------------------------------------------------
+        Schema::create('s_competency_assessments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('title', 191);
+            $table->unsignedBigInteger('framework_id')->nullable()->index();
+            $table->unsignedBigInteger('cycle_id')->nullable()->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();   // employee assessed (tbluser.id)
+            $table->unsignedBigInteger('assessor_id')->nullable();        // tbluser.id of assessor
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->string('jobrole', 191)->nullable();
+            // open | in_progress | completed | overdue
+            $table->string('status', 30)->default('open')->index();
+            // null | pending_review | reviewed
+            $table->string('review_status', 30)->nullable()->index();
+            $table->decimal('score', 5, 2)->nullable();
+            $table->date('due_date')->nullable();
+            $table->dateTime('completed_at')->nullable();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 6. Certifications ---------------------------------------------------
+        Schema::create('s_competency_certifications', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('name', 191);
+            $table->unsignedBigInteger('user_id')->nullable()->index();   // employee (tbluser.id)
+            $table->unsignedBigInteger('competency_id')->nullable()->index();
+            $table->string('issuing_body', 191)->nullable();
+            $table->string('credential_id', 191)->nullable();
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->string('jobrole', 191)->nullable();
+            // valid | expiring | expired | revoked
+            $table->string('status', 30)->default('valid')->index();
+            $table->date('issued_date')->nullable();
+            $table->date('expiry_date')->nullable()->index();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 7. Development plans ------------------------------------------------
+        Schema::create('s_competency_development_plans', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('title', 191);
+            $table->unsignedBigInteger('user_id')->nullable()->index();   // employee (tbluser.id)
+            $table->unsignedBigInteger('competency_id')->nullable()->index();
+            $table->unsignedBigInteger('framework_id')->nullable()->index();
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->string('jobrole', 191)->nullable();
+            // active | completed | overdue | on_hold
+            $table->string('status', 30)->default('active')->index();
+            $table->unsignedTinyInteger('progress')->default(0);          // 0..100
+            $table->date('start_date')->nullable();
+            $table->date('due_date')->nullable()->index();
+            $table->dateTime('completed_at')->nullable();
+            $table->unsignedBigInteger('approver_id')->nullable()->index();
+            // null | pending_approval | approved | rejected
+            $table->string('approval_status', 30)->nullable()->index();
+            $table->unsignedBigInteger('mentor_id')->nullable();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 8. Activity log (drives the Recent Activity feed) ------------------
+        Schema::create('s_competency_activity_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();   // actor (tbluser.id)
+            $table->string('actor_name', 191)->nullable();
+            $table->string('action', 191);
+            $table->text('description')->nullable();
+            $table->string('subject_type', 100)->nullable();
+            $table->unsignedBigInteger('subject_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_activity_log');
+        Schema::dropIfExists('s_competency_development_plans');
+        Schema::dropIfExists('s_competency_certifications');
+        Schema::dropIfExists('s_competency_assessments');
+        Schema::dropIfExists('s_competency_assessment_cycles');
+        Schema::dropIfExists('s_competency_framework_items');
+        Schema::dropIfExists('s_competency_frameworks');
+    }
+};

--- a/database/migrations/2026_07_28_110000_add_competency_type_to_s_users_skills.php
+++ b/database/migrations/2026_07_28_110000_add_competency_type_to_s_users_skills.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds a nullable `competency_type` (KASA) column to the existing skills
+ * catalog (s_users_skills). A competency IS an approved skill in this ERP, and
+ * the new Competency Library screen exposes a first-class "Type (KASA)" field
+ * (Behaviour / Skill / Ability / Attitude / Knowledge) that had no home on the
+ * table. Purely additive: nullable, indexed, defaulted to NULL, so every
+ * existing consumer of s_users_skills (Skill Library, competency analytics,
+ * seeders) is unaffected.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s_users_skills', function (Blueprint $table) {
+            if (!Schema::hasColumn('s_users_skills', 'competency_type')) {
+                $table->string('competency_type', 50)->nullable()->index()->after('category');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s_users_skills', function (Blueprint $table) {
+            if (Schema::hasColumn('s_users_skills', 'competency_type')) {
+                $table->dropColumn('competency_type');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_28_120000_backfill_competency_type_default.php
+++ b/database/migrations/2026_07_28_120000_backfill_competency_type_default.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Backfills the newly-added s_users_skills.competency_type (KASA) column for
+ * pre-existing rows. Every row in s_users_skills is, by definition, a Skill in
+ * the KSAAB model, so 'Skill' is the correct default classification for legacy
+ * competencies that never had a type. New competencies created/edited via the
+ * Competency Library set their own type (defaulting to 'Skill' when omitted).
+ *
+ * Data-only migration: touches just the new column's NULLs, no schema change.
+ * down() is intentionally a no-op — once set, backfilled and user-set 'Skill'
+ * values are indistinguishable, so reversing would risk clobbering real data.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('s_users_skills')
+            ->whereNull('competency_type')
+            ->update(['competency_type' => 'Skill']);
+    }
+
+    public function down(): void
+    {
+        // Intentionally left blank (see class docblock).
+    }
+};

--- a/database/migrations/2026_07_28_130000_create_competency_studio_tables.php
+++ b/database/migrations/2026_07_28_130000_create_competency_studio_tables.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Framework & Role Mapping Studio — the two genuinely-new domain tables the
+ * studio needs that have no existing equivalent in the 221-table schema.
+ *
+ * Everything else the studio renders reuses existing tables:
+ *   - Frameworks / framework items -> s_competency_frameworks / _framework_items
+ *   - Role mapping matrix cells     -> s_user_skill_jobrole (jobrole,skill,proficiency_level)
+ *   - Proficiency scale             -> s_proficiency_levels (+ KASA s_proficiency_*)
+ *   - Category tree / competencies  -> s_users_skills
+ *
+ * The two tables below (category weighting + a mapping-change approval queue)
+ * were confirmed to have NO backing table or API in either the current backend
+ * or the old frontend (both were static mock there). Conventions mirror the
+ * 2026 competency migration: bigIncrements PK, indexed sub_institute_id, nullable
+ * audit columns, timestamps + softDeletes, string status enums, loose joins.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 1. Per-category weighting for a framework's competency scoring -------
+        Schema::create('s_competency_framework_weights', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            // Null framework_id = the tenant's default weighting profile.
+            $table->unsignedBigInteger('framework_id')->nullable()->index();
+            $table->string('category', 191);
+            $table->decimal('weight', 5, 2)->default(0);
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 2. Role-mapping change approval queue (Workflow & Review tab) --------
+        Schema::create('s_competency_mapping_reviews', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('jobrole', 191);
+            $table->string('department', 191)->nullable();
+            $table->unsignedBigInteger('department_id')->nullable();
+            $table->unsignedBigInteger('framework_id')->nullable()->index();
+            $table->unsignedBigInteger('submitted_by')->nullable();   // tbluser.id
+            $table->string('submitted_by_name', 191)->nullable();
+            // pending | approved | rejected
+            $table->string('status', 30)->default('pending')->index();
+            $table->unsignedInteger('changes_count')->default(0);
+            $table->text('changes')->nullable();                      // human summary / JSON of edits
+            $table->text('note')->nullable();                         // reviewer note
+            $table->unsignedBigInteger('reviewer_id')->nullable();
+            $table->dateTime('reviewed_at')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_mapping_reviews');
+        Schema::dropIfExists('s_competency_framework_weights');
+    }
+};

--- a/database/migrations/2026_07_28_140000_create_competency_employee_notes_table.php
+++ b/database/migrations/2026_07_28_140000_create_competency_employee_notes_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Private per-employee notes for the Employee Competency Profile "Notes" panel.
+ * One row per (tenant, employee). No existing table fits: lms_content_notes is
+ * course-content notes, not competency-profile notes.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('s_competency_employee_notes', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->unsignedBigInteger('user_id')->index(); // employee (tbluser.id)
+            $table->text('note')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_employee_notes');
+    }
+};

--- a/database/migrations/2026_07_28_150000_create_competency_evidence_table.php
+++ b/database/migrations/2026_07_28_150000_create_competency_evidence_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Evidence Repository for the Employee Competency Profile — per-employee proof
+ * items (certificates, projects, documents, endorsements) optionally tied to a
+ * competency. No existing table fits: the hpbrain_*_evidence tables belong to a
+ * separate product (tenant_id, not sub_institute_id) and staff_document is HR
+ * paperwork, not competency evidence.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('s_competency_evidence', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->unsignedBigInteger('user_id')->index();          // employee (tbluser.id)
+            $table->unsignedBigInteger('competency_id')->nullable()->index(); // s_users_skills.id
+            $table->string('title', 191);
+            // certification | project | document | endorsement | training
+            $table->string('evidence_type', 50)->default('document');
+            $table->text('description')->nullable();
+            $table->string('link', 500)->nullable();
+            // verified | pending
+            $table->string('status', 30)->default('pending')->index();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_evidence');
+    }
+};

--- a/database/migrations/2026_07_29_100000_create_competency_career_path_tables.php
+++ b/database/migrations/2026_07_29_100000_create_competency_career_path_tables.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Named career paths for the Development & Career Path Workspace.
+ *
+ * The existing `career_journey` table (read by CareerJourneyController, used by
+ * the old frontend's Succession screen) stores the role-progression GRAPH as
+ * edges: jobrole_id -> to_jobrole_id + vertical_lateral_movement. That is the
+ * right source for "which role can follow which", and this migration does not
+ * touch or duplicate it.
+ *
+ * What it cannot express is a NAMED, ordered path ("Engineering Leadership
+ * Path") that a development plan can be linked to and that HR authors and
+ * publishes - there is no name, no ownership, no status and no explicit step
+ * order on an edge table. A sweep of the 221-table schema (%path%, %succession%,
+ * %progression%, %plan%) found no other candidate. Hence the two tables below.
+ *
+ * Conventions mirror 2026_07_28_100100_create_competency_module_tables:
+ * bigIncrements PK, indexed sub_institute_id, nullable audit columns,
+ * timestamps + softDeletes, string status enums, loose joins (jobrole string
+ * alongside the id) with no FK constraints.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 1. The path itself --------------------------------------------------
+        Schema::create('s_competency_career_paths', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('name', 191);
+            $table->text('description')->nullable();
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->string('department', 191)->nullable();
+            // s_user_jobrole.jobrole_category - "Engineering", "Finance", ...
+            $table->string('job_family', 191)->nullable();
+            // draft | active | archived
+            $table->string('status', 30)->default('active')->index();
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 2. Its ordered role nodes -------------------------------------------
+        Schema::create('s_competency_career_path_steps', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->unsignedBigInteger('career_path_id')->index();
+            // Both kept: jobrole_id joins s_user_jobrole, jobrole survives a
+            // role rename/delete the same way s_user_skill_jobrole does.
+            $table->unsignedBigInteger('jobrole_id')->nullable()->index();
+            $table->string('jobrole', 191);
+            $table->string('job_level', 191)->nullable();
+            $table->unsignedInteger('step_order')->default(0);
+            // current | next | future - drives the Career Path Explorer node styling
+            $table->string('step_type', 30)->default('future');
+            $table->text('description')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_career_path_steps');
+        Schema::dropIfExists('s_competency_career_paths');
+    }
+};

--- a/database/migrations/2026_07_29_100100_create_competency_plan_actions_table.php
+++ b/database/migrations/2026_07_29_100100_create_competency_plan_actions_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Action items / milestones inside a development plan.
+ *
+ * s_competency_development_plans holds only the plan header (title, owner,
+ * dates, a hand-entered progress integer). The Development & Career Path
+ * Workspace's plan detail panel needs the plan's actual contents: the "Actions"
+ * tab and the "Next Milestone" card, and it needs plan progress to be derived
+ * from completed actions rather than typed in.
+ *
+ * No milestone/action/goal table exists in the schema (checked %plan%,
+ * %milestone%, %goal%, %action% - only s_competency_activity_log, which is an
+ * append-only audit feed, not a work list). Hence this table.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('s_competency_plan_actions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->unsignedBigInteger('plan_id')->index();
+            $table->string('title', 191);
+            $table->text('description')->nullable();
+            // milestone | training | mentoring | project | reading | other
+            $table->string('action_type', 50)->default('milestone')->index();
+            // pending | in_progress | completed | blocked
+            $table->string('status', 30)->default('pending')->index();
+            // Optional competency this action closes the gap on (s_users_skills.id)
+            $table->unsignedBigInteger('competency_id')->nullable()->index();
+            $table->unsignedBigInteger('owner_id')->nullable();   // tbluser.id
+            $table->date('due_date')->nullable()->index();
+            $table->dateTime('completed_at')->nullable();
+            $table->unsignedInteger('sequence')->default(0);
+            $table->unsignedBigInteger('created_by')->index()->nullable();
+            $table->unsignedBigInteger('updated_by')->index()->nullable();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_plan_actions');
+    }
+};

--- a/database/migrations/2026_07_29_100200_add_plan_detail_columns_to_competency_development_plans.php
+++ b/database/migrations/2026_07_29_100200_add_plan_detail_columns_to_competency_development_plans.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Plan-detail columns for the workspace's "Plan Overview" tab.
+ *
+ * The detail panel shows an Objective paragraph, a Key Focus Areas list and a
+ * Linked Career Path - none of which s_competency_development_plans could hold.
+ *
+ * All three are nullable with no default change, so every existing consumer
+ * (DevelopmentPlanController@index/store/destroy, the Command Center counts,
+ * EmployeeCompetencyProfileController@developmentPlans) keeps working unchanged:
+ * they select explicit columns or `*` and never insert these.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s_competency_development_plans', function (Blueprint $table) {
+            if (!Schema::hasColumn('s_competency_development_plans', 'objective')) {
+                $table->text('objective')->nullable()->after('title');
+            }
+            if (!Schema::hasColumn('s_competency_development_plans', 'focus_areas')) {
+                // Comma-separated competency/theme labels, same style as
+                // s_user_jobrole.related_jobrole.
+                $table->text('focus_areas')->nullable()->after('objective');
+            }
+            if (!Schema::hasColumn('s_competency_development_plans', 'career_path_id')) {
+                $table->unsignedBigInteger('career_path_id')->nullable()->index()->after('framework_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s_competency_development_plans', function (Blueprint $table) {
+            foreach (['objective', 'focus_areas', 'career_path_id'] as $column) {
+                if (Schema::hasColumn('s_competency_development_plans', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_29_100300_add_competency_link_to_lms_assignments_table.php
+++ b/database/migrations/2026_07_29_100300_add_competency_link_to_lms_assignments_table.php
@@ -1,0 +1,132 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Links LMS learning assignments to the competency module.
+ *
+ * The Development & Career Path Workspace's "Learning Assignments" tab assigns
+ * a course (sub_std_map) to an employee with a due date and tracks progress.
+ * `lms_assignments` already models exactly that - user_id, course_id,
+ * assignment_type, due_date, status, progress, assigned_by, approval workflow -
+ * so this migration reuses it rather than adding a parallel
+ * s_competency_learning_assignments table.
+ *
+ * IMPORTANT - shared ownership:
+ * `lms_assignments` is created by migration 2026_07_28_094337_create_lms_assignments_table,
+ * which belongs to the in-flight LMS work on another branch and is not present
+ * in this tree. Every operation here is therefore guarded:
+ *   - the table is created only if it is genuinely absent (so a fresh install of
+ *     this branch alone still works), matching the live schema column for column;
+ *   - each new column is added only if missing, so re-running after the LMS
+ *     branch merges is a no-op rather than a failure;
+ *   - down() drops only the columns added here, never the table.
+ *
+ * The added `source` column is what keeps the two consumers separated: rows
+ * this workspace creates are tagged 'competency' and the competency endpoints
+ * filter on it, so LMS-owned assignments never leak into the competency tab and
+ * vice versa.
+ */
+return new class extends Migration
+{
+    /**
+     * The LMS branch's own migration for this table. Its timestamp is earlier
+     * than this file's, so when both exist it runs first and this migration
+     * only adds columns. The one case that needs handling is the reverse: this
+     * branch migrating a fresh database ALONE (creating the table below), then
+     * the LMS branch merging - its Schema::create would then hit an existing
+     * table. Recording it as already-run avoids that without editing their file.
+     */
+    private const LMS_OWNER_MIGRATION = '2026_07_28_094337_create_lms_assignments_table';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable('lms_assignments')) {
+            Schema::create('lms_assignments', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('user_id');
+                $table->unsignedBigInteger('course_id');
+                $table->string('assignment_type', 191)->default('Mandatory');
+                $table->date('due_date')->nullable();
+                $table->string('status', 191)->default('Not Started');
+                $table->enum('approval_status', ['approved', 'pending', 'rejected'])->default('approved')->index();
+                $table->unsignedBigInteger('requested_by')->nullable();
+                $table->unsignedBigInteger('reviewed_by')->nullable();
+                $table->timestamp('reviewed_at')->nullable();
+                $table->string('review_note', 500)->nullable();
+                $table->integer('progress')->default(0);
+                $table->string('assigned_by', 191)->nullable();
+                $table->timestamp('assigned_on')->nullable();
+                $table->unsignedBigInteger('sub_institute_id')->nullable();
+                $table->timestamps();
+                $table->softDeletes();
+            });
+
+            $this->claimOwnerMigration();
+        }
+
+        Schema::table('lms_assignments', function (Blueprint $table) {
+            if (!Schema::hasColumn('lms_assignments', 'development_plan_id')) {
+                $table->unsignedBigInteger('development_plan_id')->nullable()->index();
+            }
+            if (!Schema::hasColumn('lms_assignments', 'competency_id')) {
+                $table->unsignedBigInteger('competency_id')->nullable()->index();
+            }
+            if (!Schema::hasColumn('lms_assignments', 'assigned_by_id')) {
+                // `assigned_by` is a display name (varchar); this is the tbluser id.
+                $table->unsignedBigInteger('assigned_by_id')->nullable();
+            }
+            if (!Schema::hasColumn('lms_assignments', 'source')) {
+                // 'competency' = created by the Development & Career workspace.
+                $table->string('source', 30)->nullable()->index();
+            }
+        });
+    }
+
+    /**
+     * Mark the LMS branch's create-table migration as already applied, so a
+     * later `migrate` after that branch merges skips it instead of failing on
+     * the table this migration just created. No-op when it is already recorded
+     * (the normal case: their migration ran first and really did create it).
+     */
+    private function claimOwnerMigration(): void
+    {
+        if (!Schema::hasTable('migrations')) {
+            return;
+        }
+
+        $alreadyRecorded = DB::table('migrations')
+            ->where('migration', self::LMS_OWNER_MIGRATION)
+            ->exists();
+
+        if ($alreadyRecorded) {
+            return;
+        }
+
+        DB::table('migrations')->insert([
+            'migration' => self::LMS_OWNER_MIGRATION,
+            'batch'     => (int) (DB::table('migrations')->max('batch') ?? 0) ?: 1,
+        ]);
+    }
+
+    public function down(): void
+    {
+        // The LMS_OWNER_MIGRATION marker is deliberately left in place: the
+        // table itself is not dropped here, so un-recording it would make a
+        // later `migrate` try to create a table that still exists.
+        if (!Schema::hasTable('lms_assignments')) {
+            return;
+        }
+
+        Schema::table('lms_assignments', function (Blueprint $table) {
+            foreach (['development_plan_id', 'competency_id', 'assigned_by_id', 'source'] as $column) {
+                if (Schema::hasColumn('lms_assignments', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_29_110000_create_competency_certification_requirements_table.php
+++ b/database/migrations/2026_07_29_110000_create_competency_certification_requirements_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Certification requirements - the policy layer behind the Certification &
+ * Compliance Center ("certification X is required for job role Y / department
+ * Z"). Drives the header's "Add Certification Requirement" action, the
+ * Requirements + Compliance side-panel tabs and the Compliant Employees KPI.
+ *
+ * No existing table fits. The whole 244-table schema was audited for
+ * cert/credential/compliance/licence/accreditation concepts:
+ *  - master_compliance is the Institute Settings org-obligation register
+ *    (standard_name + a single assigned_to + duedate + frequency) and already
+ *    has three consumers (instituteDetailController CRUD, orgDashboard,
+ *    lmsActivityStream). It has no notion of a job role or of "who must hold
+ *    this", so reusing it would corrupt those screens.
+ *  - lms_certificates is an LMS course-completion certificate (course_id,
+ *    enrollment_id, verification_code) with no migration or consumer in this
+ *    repo, i.e. a different concept on another branch.
+ *  - staff_document / hrms_salary_certificate are HR paperwork.
+ *
+ * Conventions mirror the sibling competency migrations: bigIncrements PK,
+ * indexed sub_institute_id, loose joins (jobrole string / department_id int)
+ * with no FK constraints, string status, audit columns + soft deletes.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('s_competency_certification_requirements', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            $table->string('name', 191);
+            // Industry Certification | Internal Certification | Regulatory | License | Vendor
+            $table->string('certification_type', 100)->nullable()->index();
+            $table->string('issuing_body', 191)->nullable();
+            $table->text('description')->nullable();
+
+            // Scope: who the requirement applies to. All nullable - a row scoped
+            // to neither is an organisation-wide requirement.
+            $table->unsignedBigInteger('department_id')->nullable()->index();
+            $table->string('jobrole', 191)->nullable()->index();
+            $table->unsignedBigInteger('competency_id')->nullable()->index(); // s_users_skills.id
+
+            $table->boolean('is_mandatory')->default(true)->index();
+            $table->unsignedSmallInteger('validity_months')->nullable();
+            $table->unsignedSmallInteger('renewal_reminder_days')->default(60);
+            $table->unsignedSmallInteger('grace_period_days')->nullable();
+
+            // active | archived
+            $table->string('status', 30)->default('active')->index();
+
+            $table->unsignedBigInteger('created_by')->nullable()->index();
+            $table->unsignedBigInteger('updated_by')->nullable()->index();
+            $table->unsignedBigInteger('deleted_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_certification_requirements');
+    }
+};

--- a/database/migrations/2026_07_29_110100_add_compliance_columns_to_competency_certifications.php
+++ b/database/migrations/2026_07_29_110100_add_compliance_columns_to_competency_certifications.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Additive columns on s_competency_certifications for the Certification &
+ * Compliance Center. Each one backs an element of that screen that previously
+ * had no home on the table:
+ *
+ *  - certification_type   -> the "Certification Type" filter + the Overview
+ *                            panel's "Certification Type" field.
+ *  - verification_status  -> the "Pending Verification" KPI card and the
+ *                            Verify / Reject row + bulk actions.
+ *  - verified_by/_at      -> who signed the credential off and when.
+ *  - notes                -> the Overview panel's Notes block.
+ *  - requirement_id       -> links a held credential to the requirement it
+ *                            satisfies (s_competency_certification_requirements).
+ *
+ * Purely additive and nullable (verification_status defaults to 'pending' only
+ * for rows created from now on; existing rows stay NULL until backfilled by the
+ * seeder). The four existing consumers - CommandCenterService counts,
+ * EmployeeCompetencyProfileController::certifications, the command-center
+ * quick-create POST and employeeProfileService.addCertification - all read or
+ * write explicit column lists, so none of them sees a change.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s_competency_certifications', function (Blueprint $table) {
+            if (!Schema::hasColumn('s_competency_certifications', 'certification_type')) {
+                $table->string('certification_type', 100)->nullable()->index()->after('issuing_body');
+            }
+            if (!Schema::hasColumn('s_competency_certifications', 'verification_status')) {
+                // pending | verified | rejected
+                $table->string('verification_status', 30)->nullable()->index()->after('status');
+            }
+            if (!Schema::hasColumn('s_competency_certifications', 'verified_by')) {
+                $table->unsignedBigInteger('verified_by')->nullable()->after('verification_status');
+            }
+            if (!Schema::hasColumn('s_competency_certifications', 'verified_at')) {
+                $table->dateTime('verified_at')->nullable()->after('verified_by');
+            }
+            if (!Schema::hasColumn('s_competency_certifications', 'notes')) {
+                $table->text('notes')->nullable()->after('expiry_date');
+            }
+            if (!Schema::hasColumn('s_competency_certifications', 'requirement_id')) {
+                $table->unsignedBigInteger('requirement_id')->nullable()->index()->after('competency_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s_competency_certifications', function (Blueprint $table) {
+            foreach (['certification_type', 'verification_status', 'verified_by', 'verified_at', 'notes', 'requirement_id'] as $column) {
+                if (Schema::hasColumn('s_competency_certifications', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_29_110200_add_certification_link_to_competency_evidence.php
+++ b/database/migrations/2026_07_29_110200_add_certification_link_to_competency_evidence.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lets the existing Evidence Repository (s_competency_evidence) also serve as
+ * the document store for the Certification & Compliance Center, instead of
+ * creating a second near-identical table.
+ *
+ * s_competency_evidence already models "per-employee proof items (certificates,
+ * projects, documents, endorsements) optionally tied to a competency" with a
+ * link + verification status - a certificate PDF is exactly that. It was only
+ * missing (a) which certification the proof belongs to and (b) somewhere to
+ * record an uploaded file rather than an external URL.
+ *
+ * Additive and nullable, so the Employee Profile's Evidence tab (the existing
+ * consumer) is unaffected; rows created from the certification panel simply
+ * also surface there, which is the intended cross-screen behaviour.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s_competency_evidence', function (Blueprint $table) {
+            if (!Schema::hasColumn('s_competency_evidence', 'certification_id')) {
+                $table->unsignedBigInteger('certification_id')->nullable()->index()->after('competency_id');
+            }
+            if (!Schema::hasColumn('s_competency_evidence', 'file_name')) {
+                $table->string('file_name', 191)->nullable()->after('link');
+            }
+            if (!Schema::hasColumn('s_competency_evidence', 'file_path')) {
+                $table->string('file_path', 500)->nullable()->after('file_name');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s_competency_evidence', function (Blueprint $table) {
+            foreach (['certification_id', 'file_name', 'file_path'] as $column) {
+                if (Schema::hasColumn('s_competency_evidence', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_29_120000_add_audit_columns_to_competency_activity_log.php
+++ b/database/migrations/2026_07_29_120000_add_audit_columns_to_competency_activity_log.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Additive columns on s_competency_activity_log for the Audit & Activity Center.
+ *
+ * The feed table was built to drive the Command Center's "Recent Activity"
+ * strip, where a single free-text `description` line is enough. The Audit &
+ * Activity Center needs two things that line cannot give it:
+ *
+ *  - subject_name -> the table's own "Record Name" column and the detail
+ *                    panel's "Record Name" field. Today the record's name is
+ *                    only embedded inside the description string
+ *                    (e.g. 'Added certification "PMP Certification"'), so it
+ *                    cannot be selected, sorted or searched on its own.
+ *  - changes      -> the detail panel's "Change Summary" card and the
+ *                    "Version History" tab, both of which are field-level
+ *                    before/after tables. Nothing in this schema records what
+ *                    a value used to be. Stored as a JSON array of
+ *                    {field, label, old, new} objects, the same shape the
+ *                    (unrelated, different-product) hpbrain_audit_logs.changes
+ *                    column uses.
+ *
+ * A table audit of all 248 tables found no reusable audit store:
+ * hpbrain_audit_logs is another product (UUID tenant_id/actor_id, no
+ * sub_institute_id, no PHP consumer here), tbl_user_journey_logs is
+ * page-visit clickstream, and template_versions / hpbrain_capability_versions
+ * are document-template and capability versioning. So the module's own feed
+ * table is extended rather than a new one created.
+ *
+ * Both columns are nullable with no default, so the four existing readers -
+ * CertificationController::history, DevelopmentPlanController::history,
+ * skillLibraryController::competencyLibraryDetail and
+ * CommandCenterService::recentActivity - are unaffected: they all select
+ * explicit columns and none of them writes to this table directly (every write
+ * goes through ResolvesCompetencyContext::logCompetencyActivity, whose two new
+ * parameters are optional and default to null).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s_competency_activity_log', function (Blueprint $table) {
+            if (!Schema::hasColumn('s_competency_activity_log', 'subject_name')) {
+                $table->string('subject_name', 191)->nullable()->after('subject_id');
+            }
+            if (!Schema::hasColumn('s_competency_activity_log', 'changes')) {
+                // [{field, label, old, new}, ...] - MariaDB aliases json to
+                // longtext, which is fine; the model casts it back to an array.
+                $table->json('changes')->nullable()->after('subject_name');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s_competency_activity_log', function (Blueprint $table) {
+            foreach (['subject_name', 'changes'] as $column) {
+                if (Schema::hasColumn('s_competency_activity_log', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_29_130000_create_competency_settings_table.php
+++ b/database/migrations/2026_07_29_130000_create_competency_settings_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Settings store for the Competency module.
+ *
+ * Backs two panels that had nowhere to persist to:
+ *  - Framework Studio -> Weighting & Configuration -> "Weighting Configuration"
+ *    (scoring model, rounding, target threshold, how unmapped competencies
+ *    count, which surfaces the weights apply to).
+ *  - Assessment & Calibration Workspace -> "View Configuration"
+ *    (self-assessment required, calibration mandatory, approval chain,
+ *    campaign defaults).
+ *
+ * A table audit of all 249 tables found no reusable settings store:
+ * hpbrain_settings is another product (varchar(36) tenant_id/user_id, no
+ * sub_institute_id, one row, no PHP consumer here); hrms_leave_workflow_settings
+ * and lms_course_settings are fixed-column tables owned by their own modules.
+ *
+ * Deliberately key/value rather than one wide column per setting, so the two
+ * panels above - and any later competency setting - share ONE table instead of
+ * adding a table per panel. `scope` names the panel ('weighting', 'assessment'),
+ * `scope_id` optionally narrows it to one record (a framework id for a
+ * per-framework weighting profile); NULL scope_id is the tenant default.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('s_competency_settings')) {
+            return;
+        }
+
+        Schema::create('s_competency_settings', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('sub_institute_id')->index();
+            // Which panel the setting belongs to: weighting | assessment
+            $table->string('scope', 50)->index();
+            // Optional narrowing (e.g. a framework id). NULL = tenant default.
+            $table->unsignedBigInteger('scope_id')->nullable()->index();
+            $table->string('key', 100);
+            $table->text('value')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+
+            // One row per setting per scope - the controllers upsert on this.
+            $table->unique(['sub_institute_id', 'scope', 'scope_id', 'key'], 's_competency_settings_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('s_competency_settings');
+    }
+};

--- a/database/migrations/2026_07_29_130100_add_type_to_competency_assessment_cycles.php
+++ b/database/migrations/2026_07_29_130100_add_type_to_competency_assessment_cycles.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Additive `type` column on s_competency_assessment_cycles.
+ *
+ * The Assessment Workspace's campaigns table has always shown an "Assessment
+ * Type" column, but AssessmentCycleController::index() hardcoded it to
+ * 'Self + Manager' because the table had nowhere to store it. The campaign
+ * detail panel's "Edit Campaign" action needs a real field to edit, so the
+ * hardcoded display value becomes a real, per-campaign column.
+ *
+ * Nullable with no default: existing rows read NULL and the controller falls
+ * back to 'Self + Manager', so the campaigns table renders exactly as before
+ * until someone edits a campaign.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('s_competency_assessment_cycles', function (Blueprint $table) {
+            if (!Schema::hasColumn('s_competency_assessment_cycles', 'type')) {
+                $table->string('type', 100)->nullable()->after('name');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('s_competency_assessment_cycles', function (Blueprint $table) {
+            if (Schema::hasColumn('s_competency_assessment_cycles', 'type')) {
+                $table->dropColumn('type');
+            }
+        });
+    }
+};

--- a/database/seeders/CompetencySeeder.php
+++ b/database/seeders/CompetencySeeder.php
@@ -1,0 +1,1352 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds realistic Competency Management data for a single tenant so the
+ * Command Center dashboard renders meaningful numbers. Draws real job roles,
+ * departments and employees from the tenant's existing tables. Idempotent:
+ * it hard-deletes only the competency-module rows for the target tenant first,
+ * so re-running never duplicates and never touches other tenants or tables.
+ *
+ * Target tenant is sub_institute_id = 1 by default (the main demo tenant);
+ * override with:  php artisan db:seed --class=CompetencySeeder  after setting
+ * COMPETENCY_SEED_TENANT in the environment.
+ */
+class CompetencySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $sid = (int) (env('COMPETENCY_SEED_TENANT', 1));
+        $now = Carbon::now();
+
+        // --- Idempotency: clear this tenant's competency-module rows ---------
+        foreach ([
+            's_competency_activity_log',
+            's_competency_evidence',
+            's_competency_mapping_reviews',
+            's_competency_framework_weights',
+            's_competency_plan_actions',
+            's_competency_development_plans',
+            's_competency_certifications',
+            's_competency_certification_requirements',
+            's_competency_assessments',
+            's_competency_framework_items',
+            's_competency_assessment_cycles',
+            's_competency_career_path_steps',
+            's_competency_career_paths',
+            's_competency_frameworks',
+        ] as $table) {
+            DB::table($table)->where('sub_institute_id', $sid)->delete();
+        }
+
+        // lms_assignments is SHARED with the LMS module - only ever touch the
+        // rows this workspace owns (source='competency'), never the LMS's own.
+        DB::table('lms_assignments')
+            ->where('sub_institute_id', $sid)
+            ->where('source', 'competency')
+            ->delete();
+
+        // --- Real source data ------------------------------------------------
+        $roles = DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->select('jobrole', 'department_id', 'department', 'location', 'industries', 'jobrole_category')
+            ->limit(60)
+            ->get();
+
+        if ($roles->isEmpty()) {
+            $this->command?->warn("CompetencySeeder: no job roles for sub_institute_id={$sid}; nothing seeded.");
+            return;
+        }
+
+        // Competencies are the existing approved skills catalog (s_users_skills)
+        // - reference real skill ids for the competency_id links below rather
+        // than seeding a duplicate competency table.
+        $competencyIds = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->limit(200)
+            ->pluck('id')
+            ->all();
+        if (empty($competencyIds)) {
+            $competencyIds = [null];
+        }
+
+        $employees = DB::table('tbluser')
+            ->where('sub_institute_id', $sid)
+            ->select('id', 'first_name', 'last_name')
+            ->limit(60)
+            ->get();
+
+        $pickRole = fn () => $roles[array_rand($roles->all())];
+        $pickEmp = fn () => $employees->isNotEmpty() ? $employees[array_rand($employees->all())] : null;
+        $empName = fn ($e) => $e ? trim(($e->first_name ?? '') . ' ' . ($e->last_name ?? '')) : 'System';
+
+        // --- Frameworks (24; ~18 active) -------------------------------------
+        $frameworkRows = [];
+        $deptNames = $roles->pluck('department')->filter()->unique()->values()->all();
+        for ($i = 0; $i < 24; $i++) {
+            $role = $pickRole();
+            $dept = $deptNames[$i % max(count($deptNames), 1)] ?? 'Corporate';
+            $status = $i < 18 ? 'active' : ($i < 22 ? 'draft' : 'archived');
+            $frameworkRows[] = [
+                'sub_institute_id' => $sid,
+                'name'             => $dept . ' Competency Framework',
+                'description'      => 'Competency framework covering the ' . $dept . ' function.',
+                'version'          => 'v' . rand(1, 3) . '.0',
+                'status'           => $status,
+                'department_id'    => $role->department_id,
+                'jobrole'          => $role->jobrole,
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => (clone $now)->subDays(rand(10, 200)),
+                'updated_at'       => $now,
+            ];
+        }
+        DB::table('s_competency_frameworks')->insert($frameworkRows);
+        $frameworkIds = DB::table('s_competency_frameworks')->where('sub_institute_id', $sid)->pluck('id')->all();
+
+        // --- 3. Framework items (map competencies into frameworks) -----------
+        $itemRows = [];
+        foreach ($frameworkIds as $fid) {
+            $count = min(count($competencyIds), rand(4, 8));
+            $picks = (array) array_rand(array_flip($competencyIds), $count);
+            foreach ($picks as $cid) {
+                $itemRows[] = [
+                    'sub_institute_id'     => $sid,
+                    'framework_id'         => $fid,
+                    'competency_id'        => $cid,
+                    'required_proficiency' => 'Level ' . rand(1, 5),
+                    'created_by'           => 1,
+                    'created_at'           => $now,
+                    'updated_at'           => $now,
+                ];
+            }
+        }
+        if ($itemRows) {
+            DB::table('s_competency_framework_items')->insert($itemRows);
+        }
+
+        // --- 4. Assessment cycles (one active spanning today) ----------------
+        $cycleRows = [
+            [
+                'sub_institute_id' => $sid,
+                'name'             => 'Q3 Competency Assessment Cycle',
+                'description'      => 'Organisation-wide competency assessment cycle.',
+                'start_date'       => (clone $now)->subDays(10)->toDateString(),
+                'end_date'         => (clone $now)->addDays(50)->toDateString(),
+                'status'           => 'active',
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => $now,
+                'updated_at'       => $now,
+            ],
+            [
+                'sub_institute_id' => $sid,
+                'name'             => 'Q4 Leadership Review',
+                'description'      => 'Leadership competency review cycle.',
+                'start_date'       => (clone $now)->addDays(70)->toDateString(),
+                'end_date'         => (clone $now)->addDays(120)->toDateString(),
+                'status'           => 'scheduled',
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => $now,
+                'updated_at'       => $now,
+            ],
+            [
+                'sub_institute_id' => $sid,
+                'name'             => 'Q1 Annual Competency Assessment',
+                'description'      => 'Closed annual competency assessment cycle.',
+                'start_date'       => (clone $now)->subDays(160)->toDateString(),
+                'end_date'         => (clone $now)->subDays(40)->toDateString(),
+                'status'           => 'closed',
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => (clone $now)->subDays(160),
+                'updated_at'       => (clone $now)->subDays(40),
+            ],
+        ];
+        DB::table('s_competency_assessment_cycles')->insert($cycleRows);
+        $activeCycleId = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $sid)->where('status', 'active')->value('id');
+        $closedCycleId = DB::table('s_competency_assessment_cycles')
+            ->where('sub_institute_id', $sid)->where('status', 'closed')->value('id');
+
+        // --- 5. Assessments (140) -------------------------------------------
+        $assessmentRows = [];
+        for ($i = 0; $i < 140; $i++) {
+            $role = $pickRole();
+            $emp = $pickEmp();
+            $assessor = $pickEmp();
+
+            // ~58% completed, ~14% in_progress, ~16% open, ~12% overdue
+            $r = $i % 50;
+            if ($r < 29) {
+                $status = 'completed';
+            } elseif ($r < 36) {
+                $status = 'in_progress';
+            } elseif ($r < 44) {
+                $status = 'open';
+            } else {
+                $status = 'overdue';
+            }
+
+            $completedAt = $status === 'completed' ? (clone $now)->subDays(rand(1, 40)) : null;
+            $score = $status === 'completed' ? rand(55, 98) + (rand(0, 99) / 100) : null;
+
+            // Due dates: overdue in the past; others spread, many within 60 days.
+            if ($status === 'overdue') {
+                $due = (clone $now)->subDays(rand(2, 25))->toDateString();
+            } else {
+                $due = (clone $now)->addDays(rand(-5, 58))->toDateString();
+            }
+
+            // ~22 completed assessments still awaiting review.
+            $reviewStatus = ($status === 'completed' && $i % 6 === 0) ? 'pending_review' : null;
+
+            // Put ~1 in 3 assessments into the closed cycle so the Closed
+            // Campaigns tab has real history; the rest into the active cycle.
+            $cycleId = ($closedCycleId && $i % 3 === 0) ? $closedCycleId : $activeCycleId;
+
+            $assessmentRows[] = [
+                'sub_institute_id' => $sid,
+                'title'            => $role->jobrole . ' Assessment',
+                'framework_id'     => $frameworkIds[array_rand($frameworkIds)],
+                'cycle_id'         => $cycleId,
+                'user_id'          => $emp->id ?? null,
+                'assessor_id'      => $assessor->id ?? null,
+                'department_id'    => $role->department_id,
+                'jobrole'          => $role->jobrole,
+                'status'           => $status,
+                'review_status'    => $reviewStatus,
+                'score'            => $score,
+                'due_date'         => $due,
+                'completed_at'     => $completedAt,
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => (clone $now)->subDays(rand(1, 60)),
+                'updated_at'       => $now,
+            ];
+        }
+        DB::table('s_competency_assessments')->insert($assessmentRows);
+
+        // --- 6. Certifications (220) ----------------------------------------
+        // Each credential carries its real issuing body and a type, so the
+        // Certification & Compliance Center's Type / Issuing Body filters and
+        // the Overview panel have genuine values to work with.
+        $certNotes = [
+            'Original certificate sighted and filed.',
+            'Renewal reminder sent to the holder.',
+            'Awaiting the issuing body to confirm the credential id.',
+            'Verified against the provider register.',
+            'Holder has booked the recertification exam.',
+        ];
+        $certCatalog = [
+            'PMP'                      => ['PMI', 'Industry Certification', 36],
+            'AWS Solutions Architect'  => ['Amazon Web Services', 'Vendor Certification', 36],
+            'CISSP'                    => ['(ISC)2', 'Industry Certification', 36],
+            'Six Sigma Green Belt'     => ['ASQ', 'Industry Certification', null],
+            'ITIL Foundation'          => ['AXELOS', 'Industry Certification', null],
+            'CFA Level I'              => ['CFA Institute', 'Regulatory', null],
+            'Scrum Master'             => ['Scrum Alliance', 'Industry Certification', 24],
+            'Google Data Analytics'    => ['Google', 'Vendor Certification', null],
+            'ISO 9001 Lead Auditor'    => ['BSI', 'Regulatory', 36],
+            'Azure Fundamentals'       => ['Microsoft', 'Vendor Certification', 24],
+        ];
+        $certNames = array_keys($certCatalog);
+        $certRows = [];
+        for ($i = 0; $i < 220; $i++) {
+            $role = $pickRole();
+            $emp = $pickEmp();
+
+            // ~74% valid, ~9% expiring, ~11% expired, ~6% revoked
+            $r = $i % 100;
+            if ($r < 74) {
+                $status = 'valid';
+            } elseif ($r < 83) {
+                $status = 'expiring';
+            } elseif ($r < 94) {
+                $status = 'expired';
+            } else {
+                $status = 'revoked';
+            }
+
+            // Expiry: expired in past; expiring within 30 days; valid mostly far
+            // future, but ~1 in 8 valid certs fall inside the 30-day window too.
+            if ($status === 'expired') {
+                $expiry = (clone $now)->subDays(rand(5, 200))->toDateString();
+            } elseif ($status === 'expiring') {
+                $expiry = (clone $now)->addDays(rand(1, 30))->toDateString();
+            } elseif ($status === 'valid' && $i % 8 === 0) {
+                $expiry = (clone $now)->addDays(rand(3, 29))->toDateString();
+            } else {
+                $expiry = (clone $now)->addDays(rand(60, 720))->toDateString();
+            }
+
+            $certName = $certNames[$i % count($certNames)];
+            [$issuingBody, $certType] = $certCatalog[$certName];
+
+            // ~25% still awaiting review (the "Pending Verification" KPI),
+            // ~65% verified, ~10% rejected.
+            $v = $i % 20;
+            $verification = $v < 5 ? 'pending' : ($v < 18 ? 'verified' : 'rejected');
+
+            $certRows[] = [
+                'sub_institute_id'    => $sid,
+                'name'                => $certName,
+                'user_id'             => $emp->id ?? null,
+                'competency_id'       => $competencyIds[array_rand($competencyIds)],
+                'issuing_body'        => $issuingBody,
+                'certification_type'  => $certType,
+                'credential_id'       => 'CRED-' . strtoupper(substr(md5($i . $sid), 0, 8)),
+                'department_id'       => $role->department_id,
+                'jobrole'             => $role->jobrole,
+                'status'              => $status,
+                'verification_status' => $verification,
+                'verified_by'         => $verification === 'pending' ? null : 1,
+                'verified_at'         => $verification === 'pending' ? null : (clone $now)->subDays(rand(1, 120)),
+                'issued_date'         => (clone $now)->subDays(rand(200, 900))->toDateString(),
+                'expiry_date'         => $expiry,
+                // Roughly one credential in four carries a reviewer note, in
+                // the same "[date - author] text" format addNote() appends. It
+                // fills the Overview panel's Notes block and is the record the
+                // Audit Center's Comments tab reports.
+                'notes'               => $i % 4 === 0
+                    ? '[' . (clone $now)->subDays(rand(2, 90))->format('d M Y') . ' - Admin User] '
+                        . $certNotes[$i % count($certNotes)]
+                    : null,
+                'created_by'          => 1,
+                'updated_by'          => 1,
+                'created_at'          => (clone $now)->subDays(rand(1, 200)),
+                'updated_at'          => $now,
+            ];
+        }
+        DB::table('s_competency_certifications')->insert($certRows);
+
+        // --- 6b. Certification requirements ---------------------------------
+        // The policy layer behind the compliance center: which credential a job
+        // role / department / the whole organisation is expected to hold. Scoped
+        // against the tenant's REAL job roles so the Requirements tab and the
+        // Compliant Employees KPI resolve against live data.
+        $requirementRows = [];
+
+        // Two organisation-wide requirements everybody is measured against.
+        foreach ([['ITIL Foundation', false], ['ISO 9001 Lead Auditor', true]] as [$name, $mandatory]) {
+            [$issuingBody, $certType, $validity] = $certCatalog[$name];
+            $requirementRows[] = [
+                'sub_institute_id'      => $sid,
+                'name'                  => $name,
+                'certification_type'    => $certType,
+                'issuing_body'          => $issuingBody,
+                'description'           => $name . ' is expected across the organisation.',
+                'department_id'         => null,
+                'jobrole'               => null,
+                'competency_id'         => null,
+                'is_mandatory'          => $mandatory ? 1 : 0,
+                'validity_months'       => $validity,
+                'renewal_reminder_days' => 60,
+                'grace_period_days'     => 30,
+                'status'                => 'active',
+                'created_by'            => 1,
+                'updated_by'            => 1,
+                'created_at'            => $now,
+                'updated_at'            => $now,
+            ];
+        }
+
+        // Role-scoped requirements over the first dozen real job roles.
+        $requirementRoles = $roles->take(12);
+        $index = 0;
+        foreach ($requirementRoles as $role) {
+            $name = $certNames[$index % count($certNames)];
+            [$issuingBody, $certType, $validity] = $certCatalog[$name];
+
+            $requirementRows[] = [
+                'sub_institute_id'      => $sid,
+                'name'                  => $name,
+                'certification_type'    => $certType,
+                'issuing_body'          => $issuingBody,
+                'description'           => $name . ' is required for the ' . $role->jobrole . ' role.',
+                'department_id'         => $role->department_id,
+                'jobrole'               => $role->jobrole,
+                'competency_id'         => null,
+                // Two thirds mandatory, the rest recommended.
+                'is_mandatory'          => $index % 3 === 2 ? 0 : 1,
+                'validity_months'       => $validity,
+                'renewal_reminder_days' => 60,
+                'grace_period_days'     => $index % 2 === 0 ? 30 : null,
+                'status'                => 'active',
+                'created_by'            => 1,
+                'updated_by'            => 1,
+                'created_at'            => $now,
+                'updated_at'            => $now,
+            ];
+            $index++;
+        }
+        DB::table('s_competency_certification_requirements')->insert($requirementRows);
+
+        // Link held credentials back to the requirement they satisfy, so the
+        // Requirements tab shows met/unmet against real rows rather than
+        // relying on name matching alone.
+        foreach (DB::table('s_competency_certification_requirements')
+            ->where('sub_institute_id', $sid)->whereNotNull('jobrole')->get() as $requirement) {
+            DB::table('s_competency_certifications')
+                ->where('sub_institute_id', $sid)
+                ->where('jobrole', $requirement->jobrole)
+                ->where('name', $requirement->name)
+                ->whereNull('deleted_at')
+                ->update(['requirement_id' => $requirement->id]);
+        }
+
+        // --- 7. Development plans (160) -------------------------------------
+        $planRows = [];
+        for ($i = 0; $i < 160; $i++) {
+            $role = $pickRole();
+            $emp = $pickEmp();
+            $approver = $pickEmp();
+
+            // ~54% active, ~30% completed, ~10% overdue, ~6% on_hold
+            $r = $i % 50;
+            if ($r < 27) {
+                $status = 'active';
+            } elseif ($r < 42) {
+                $status = 'completed';
+            } elseif ($r < 47) {
+                $status = 'overdue';
+            } else {
+                $status = 'on_hold';
+            }
+
+            $progress = match ($status) {
+                'completed' => 100,
+                'overdue'   => rand(10, 60),
+                'on_hold'   => rand(0, 40),
+                default     => rand(20, 90),
+            };
+
+            if ($status === 'overdue') {
+                $due = (clone $now)->subDays(rand(3, 40))->toDateString();
+            } elseif ($status === 'completed') {
+                $due = (clone $now)->subDays(rand(1, 30))->toDateString();
+            } else {
+                $due = (clone $now)->addDays(rand(5, 120))->toDateString();
+            }
+
+            // ~1 in 4 active/on_hold plans await approval; approver cycles
+            // through the seeded employees so approvers get real queues.
+            $pendingApproval = in_array($status, ['active', 'on_hold'], true) && $i % 4 === 0;
+
+            $planRows[] = [
+                'sub_institute_id' => $sid,
+                'title'            => 'Development Plan - ' . $role->jobrole,
+                'user_id'          => $emp->id ?? null,
+                'competency_id'    => $competencyIds[array_rand($competencyIds)],
+                'framework_id'     => $frameworkIds[array_rand($frameworkIds)],
+                'department_id'    => $role->department_id,
+                'jobrole'          => $role->jobrole,
+                'status'           => $status,
+                'progress'         => $progress,
+                'start_date'       => (clone $now)->subDays(rand(20, 120))->toDateString(),
+                'due_date'         => $due,
+                'completed_at'     => $status === 'completed' ? (clone $now)->subDays(rand(1, 25)) : null,
+                'approver_id'      => $pendingApproval ? ($approver->id ?? null) : null,
+                'approval_status'  => $pendingApproval ? 'pending_approval' : null,
+                'mentor_id'        => $pickEmp()->id ?? null,
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => (clone $now)->subDays(rand(1, 120)),
+                'updated_at'       => $now,
+            ];
+        }
+        DB::table('s_competency_development_plans')->insert($planRows);
+
+        // --- 8. Activity feed ------------------------------------------------
+        // Backfilled at the end of run(), once every domain record exists, so
+        // each entry names a row that is genuinely in the database.
+
+        // --- 9. Category weighting (default profile, framework_id = null) -----
+        // Weights the tenant's real competency categories so the Weighting tab
+        // renders a meaningful split. framework_id null = the default profile.
+        $weightCats = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->whereNotNull('category')
+            ->where('category', '!=', '')
+            ->select('category', DB::raw('COUNT(*) as c'))
+            ->groupBy('category')
+            ->orderByDesc('c')
+            ->limit(6)
+            ->pluck('category')
+            ->all();
+
+        if ($weightCats) {
+            $presetWeights = [50, 20, 15, 10, 5, 0];
+            $weightRows = [];
+            foreach ($weightCats as $idx => $category) {
+                $weightRows[] = [
+                    'sub_institute_id' => $sid,
+                    'framework_id'     => null,
+                    'category'         => $category,
+                    'weight'           => $presetWeights[$idx] ?? 0,
+                    'created_by'       => 1,
+                    'updated_by'       => 1,
+                    'created_at'       => $now,
+                    'updated_at'       => $now,
+                ];
+            }
+            DB::table('s_competency_framework_weights')->insert($weightRows);
+        }
+
+        // --- 10. Mapping-change reviews (18: pending/approved/rejected) -------
+        // Reviewer notes per outcome. Every review carries one: a reviewer
+        // leaving a remark is the module's main comment surface, and it is what
+        // the Audit Center's Comments tab reads.
+        $reviewNotes = [
+            'pending'  => [
+                'Waiting on the department head to confirm the level 4 entries.',
+                'Please attach the role profile before this can be signed off.',
+                'Holding until the framework re-publish lands next week.',
+            ],
+            'approved' => [
+                'Levels line up with the global scale - approved.',
+                'Checked against the role profile, no further changes needed.',
+                'Approved. Good improvement on the technical cluster.',
+            ],
+            'rejected' => [
+                'Levels need alignment with the global scale.',
+                'Two competencies here belong to a different job family.',
+            ],
+        ];
+
+        $reviewRows = [];
+        for ($i = 0; $i < 18; $i++) {
+            $role = $pickRole();
+            $emp = $pickEmp();
+            // ~55% pending, ~30% approved, ~15% rejected
+            $r = $i % 20;
+            $status = $r < 11 ? 'pending' : ($r < 17 ? 'approved' : 'rejected');
+            $reviewed = $status === 'pending' ? null : (clone $now)->subDays(rand(1, 20));
+            $notes = $reviewNotes[$status];
+
+            $reviewRows[] = [
+                'sub_institute_id'  => $sid,
+                'jobrole'           => $role->jobrole,
+                'department'        => $role->department,
+                'department_id'     => $role->department_id,
+                'framework_id'      => $frameworkIds[array_rand($frameworkIds)],
+                'submitted_by'      => $emp->id ?? null,
+                'submitted_by_name' => $empName($emp),
+                'status'            => $status,
+                'changes_count'     => rand(2, 14),
+                'changes'           => 'Updated required proficiency for ' . rand(2, 14) . ' competencies.',
+                'note'              => $notes[$i % count($notes)],
+                'reviewer_id'       => $status === 'pending' ? null : 1,
+                'reviewed_at'       => $reviewed,
+                'created_by'        => $emp->id ?? 1,
+                'updated_by'        => 1,
+                'created_at'        => (clone $now)->subDays(rand(1, 30)),
+                'updated_at'        => $now,
+            ];
+        }
+        DB::table('s_competency_mapping_reviews')->insert($reviewRows);
+
+        // --- 11. Evidence repository (per employee, a few items each) ---------
+        $evidenceTemplates = [
+            ['certification', 'Certificate of Completion'],
+            ['project', 'Project Portfolio Submission'],
+            ['endorsement', 'Peer Endorsement'],
+            ['training', 'Training Attendance Record'],
+            ['document', 'Assessment Report'],
+        ];
+        $evidenceRows = [];
+        foreach ($employees as $emp) {
+            $count = rand(2, 4);
+            for ($e = 0; $e < $count; $e++) {
+                $tpl = $evidenceTemplates[($emp->id + $e) % count($evidenceTemplates)];
+                $evidenceRows[] = [
+                    'sub_institute_id' => $sid,
+                    'user_id'          => $emp->id,
+                    'competency_id'    => $competencyIds[array_rand($competencyIds)],
+                    'title'            => $tpl[1],
+                    'evidence_type'    => $tpl[0],
+                    'description'      => 'Supporting evidence for competency assessment.',
+                    'link'             => null,
+                    'status'           => $e % 3 === 0 ? 'pending' : 'verified',
+                    'created_by'       => 1,
+                    'updated_by'       => 1,
+                    'created_at'       => (clone $now)->subDays(rand(5, 180)),
+                    'updated_at'       => $now,
+                ];
+            }
+        }
+        if ($evidenceRows) {
+            DB::table('s_competency_evidence')->insert($evidenceRows);
+        }
+
+        // --- 12. Role progression ladders (shared source for 13 + 14) --------
+        // This tenant has NO job_level and NO sequence_order (all NULL), and
+        // related_jobrole holds lateral peers rather than a ladder. The real
+        // seniority signal is the role NAME, which this catalog encodes
+        // consistently (Associate -> Senior -> Manager -> Partner/Director).
+        $ladders = $this->buildLadders($sid);
+
+        // --- 13. Career progression graph (career_journey) -------------------
+        // career_journey is a SHARED table read by CareerJourneyController and
+        // the old frontend's Succession screen, so this only ever populates a
+        // tenant that has none - it must never overwrite a hand-configured
+        // progression graph.
+        $existingEdges = DB::table('career_journey')->where('sub_institute_id', $sid)->count();
+
+        if ($existingEdges > 0) {
+            $this->command?->warn(
+                "CompetencySeeder: career_journey already has {$existingEdges} row(s) for sub_institute_id={$sid}; left untouched."
+            );
+        } else {
+            $edgeRows = [];
+            $seenEdges = [];
+            $addEdge = function ($from, $to, $vertical) use ($sid, $now, &$edgeRows, &$seenEdges) {
+                if (!$from || !$to || $from === $to) {
+                    return;
+                }
+                $key = $from . ':' . $to;
+                if (isset($seenEdges[$key])) {
+                    return;
+                }
+                $seenEdges[$key] = true;
+                $edgeRows[] = [
+                    'jobrole_id'                => $from,
+                    'to_jobrole_id'             => $to,
+                    'vertical_lateral_movement' => $vertical ? 1 : 0,
+                    'sub_institute_id'          => $sid,
+                    'created_at'                => $now,
+                ];
+            };
+
+            foreach ($ladders as $ladder) {
+                $steps = array_values($ladder['steps']);
+
+                // Vertical: each rung to the next one up.
+                for ($i = 0; $i < count($steps) - 1; $i++) {
+                    $addEdge($steps[$i]->id, $steps[$i + 1]->id, true);
+                }
+
+                // Lateral: same-rung peers in the department, plus any
+                // related_jobrole that resolves to a real role in this tenant.
+                foreach ($steps as $step) {
+                    foreach (array_slice($ladder['peers'][$step->id] ?? [], 0, 2) as $peerId) {
+                        $addEdge($step->id, $peerId, false);
+                    }
+                }
+            }
+
+            if ($edgeRows) {
+                foreach (array_chunk($edgeRows, 500) as $chunk) {
+                    DB::table('career_journey')->insert($chunk);
+                }
+            }
+            $this->command?->info('CompetencySeeder: seeded ' . count($edgeRows) . ' career_journey edges.');
+        }
+
+        // --- 14. Named career paths (+ ordered steps) ------------------------
+        // The 12 deepest ladders become published paths the workspace can link
+        // development plans to.
+        $deepest = $ladders;
+        usort($deepest, fn ($a, $b) => count($b['steps']) <=> count($a['steps']));
+        $deepest = array_slice($deepest, 0, 12);
+
+        $pathIdByRole = [];   // jobrole name => career_path_id, for linking plans
+        foreach ($deepest as $ladder) {
+            $steps = array_values($ladder['steps']);
+            $pathId = DB::table('s_competency_career_paths')->insertGetId([
+                'sub_institute_id' => $sid,
+                'name'             => $ladder['department'] . ' Career Path',
+                'description'      => 'Progression ladder for the ' . $ladder['department'] . ' function.',
+                'department_id'    => $ladder['department_id'],
+                'department'       => $ladder['department'],
+                'job_family'       => null,
+                'status'           => 'active',
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => (clone $now)->subDays(rand(5, 90)),
+                'updated_at'       => $now,
+            ]);
+
+            $stepRows = [];
+            foreach ($steps as $order => $step) {
+                $pathIdByRole[$step->jobrole] = $pathId;
+                $stepRows[] = [
+                    'sub_institute_id' => $sid,
+                    'career_path_id'   => $pathId,
+                    'jobrole_id'       => $step->id,
+                    'jobrole'          => $step->jobrole,
+                    'job_level'        => $step->job_level,
+                    'step_order'       => $order,
+                    'step_type'        => $order === 0 ? 'current' : ($order === 1 ? 'next' : 'future'),
+                    'description'      => null,
+                    'created_by'       => 1,
+                    'created_at'       => $now,
+                    'updated_at'       => $now,
+                ];
+            }
+            DB::table('s_competency_career_path_steps')->insert($stepRows);
+        }
+
+        // --- 15. Plan objective / focus areas / linked path ------------------
+        // Focus areas reference the competencies the plan's job role actually
+        // requires (s_user_skill_jobrole), so the Gaps tab's "Focus" badges land
+        // on real rows instead of invented labels.
+        $plans = DB::table('s_competency_development_plans')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->get(['id', 'title', 'jobrole', 'status', 'progress']);
+
+        $planJobroles = $plans->pluck('jobrole')->filter()->unique()->values()->all();
+        $skillsByRole = [];
+        if ($planJobroles) {
+            $skillsByRole = DB::table('s_user_skill_jobrole')
+                ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+                ->whereIn('jobrole', $planJobroles)
+                ->get(['jobrole', 'skill'])
+                ->groupBy('jobrole')
+                ->map(fn ($group) => $group->pluck('skill')->unique()->values()->all())
+                ->all();
+        }
+
+        foreach ($plans as $plan) {
+            $skills = $skillsByRole[$plan->jobrole] ?? [];
+            $focus = array_slice($skills, 0, rand(2, 4));
+
+            DB::table('s_competency_development_plans')->where('id', $plan->id)->update([
+                'objective'      => 'Close the competency gaps required for the '
+                                    . ($plan->jobrole ?: 'target') . ' role and build readiness for the next step on the career path.',
+                'focus_areas'    => $focus ? implode(',', $focus) : null,
+                'career_path_id' => $pathIdByRole[$plan->jobrole] ?? null,
+                'updated_at'     => $now,
+            ]);
+        }
+
+        // --- 16. Plan action items -------------------------------------------
+        // ~60% of plans get a real work list. The completed count is derived
+        // from the plan's seeded progress and the progress is then written back
+        // from the actions, so the two can never disagree in the UI.
+        $actionTemplates = [
+            ['project',   'Lead a cross-functional project'],
+            ['training',  'Complete the required certification course'],
+            ['mentoring', 'Fortnightly mentoring sessions with the plan owner'],
+            ['reading',   'Work through the recommended reading list'],
+            ['milestone', 'Present findings to the leadership team'],
+            ['milestone', 'Shadow a senior colleague for one delivery cycle'],
+        ];
+
+        $actionRows = [];
+        $progressUpdates = [];
+        foreach ($plans as $index => $plan) {
+            if ($index % 5 >= 3) {
+                continue;   // leave ~40% of plans with no actions
+            }
+
+            $total = rand(3, 5);
+            $done = (int) round(($plan->progress / 100) * $total);
+            $done = max(0, min($done, $total));
+
+            for ($a = 0; $a < $total; $a++) {
+                $tpl = $actionTemplates[($plan->id + $a) % count($actionTemplates)];
+                $isDone = $a < $done;
+
+                $actionRows[] = [
+                    'sub_institute_id' => $sid,
+                    'plan_id'          => $plan->id,
+                    'title'            => $tpl[1],
+                    'description'      => null,
+                    'action_type'      => $tpl[0],
+                    'status'           => $isDone ? 'completed' : ($a === $done ? 'in_progress' : 'pending'),
+                    'competency_id'    => $competencyIds[array_rand($competencyIds)],
+                    'owner_id'         => null,
+                    'due_date'         => (clone $now)->addDays(($a + 1) * rand(10, 25))->toDateString(),
+                    'completed_at'     => $isDone ? (clone $now)->subDays(rand(1, 40)) : null,
+                    'sequence'         => $a,
+                    'created_by'       => 1,
+                    'updated_by'       => 1,
+                    'created_at'       => (clone $now)->subDays(rand(5, 100)),
+                    'updated_at'       => $now,
+                ];
+            }
+
+            $progressUpdates[(int) round($done / $total * 100)][] = $plan->id;
+        }
+
+        if ($actionRows) {
+            foreach (array_chunk($actionRows, 500) as $chunk) {
+                DB::table('s_competency_plan_actions')->insert($chunk);
+            }
+            // One UPDATE per distinct progress value rather than per plan.
+            foreach ($progressUpdates as $progress => $ids) {
+                DB::table('s_competency_development_plans')
+                    ->whereIn('id', $ids)->update(['progress' => $progress, 'updated_at' => $now]);
+            }
+        }
+
+        // --- 17. Learning assignments (lms_assignments, source='competency') --
+        $courses = DB::table('sub_std_map')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')->where('status', 1)
+            ->whereNotNull('display_name')->where('display_name', '!=', '')
+            ->limit(40)->get(['id', 'display_name']);
+
+        if ($courses->isEmpty() || $employees->isEmpty()) {
+            $this->command?->warn('CompetencySeeder: no courses or employees for sub_institute_id=' . $sid . '; learning assignments skipped.');
+        } else {
+            $planList = $plans->values();
+            $learningRows = [];
+
+            for ($i = 0; $i < 48; $i++) {
+                $course = $courses[$i % $courses->count()];
+                $emp = $pickEmp();
+                if (!$emp) {
+                    continue;
+                }
+
+                // ~30% completed, ~30% in progress, ~30% not started, ~10% overdue
+                $r = $i % 10;
+                if ($r < 3) {
+                    $status = 'Completed';
+                    $progress = 100;
+                    $due = (clone $now)->subDays(rand(5, 60))->toDateString();
+                } elseif ($r < 6) {
+                    $status = 'In Progress';
+                    $progress = rand(15, 85);
+                    $due = (clone $now)->addDays(rand(5, 60))->toDateString();
+                } elseif ($r < 9) {
+                    $status = 'Not Started';
+                    $progress = 0;
+                    $due = (clone $now)->addDays(rand(10, 90))->toDateString();
+                } else {
+                    $status = 'Overdue';
+                    $progress = rand(5, 55);
+                    $due = (clone $now)->subDays(rand(3, 30))->toDateString();
+                }
+
+                // ~2 in 3 assignments hang off a development plan.
+                $plan = ($i % 3 !== 0 && $planList->isNotEmpty()) ? $planList[$i % $planList->count()] : null;
+
+                $learningRows[] = [
+                    'sub_institute_id'    => $sid,
+                    'user_id'             => $emp->id,
+                    'course_id'           => $course->id,
+                    'assignment_type'     => $i % 4 === 0 ? 'Recommended' : ($i % 7 === 0 ? 'Optional' : 'Mandatory'),
+                    'status'              => $status,
+                    'progress'            => $progress,
+                    'approval_status'     => 'approved',
+                    'due_date'            => $due,
+                    'assigned_by'         => 'Admin User',
+                    'assigned_by_id'      => 1,
+                    'assigned_on'         => (clone $now)->subDays(rand(5, 120)),
+                    'development_plan_id' => $plan->id ?? null,
+                    'competency_id'       => $competencyIds[array_rand($competencyIds)],
+                    'source'              => 'competency',
+                    'created_at'          => (clone $now)->subDays(rand(5, 120)),
+                    'updated_at'          => $now,
+                ];
+            }
+
+            if ($learningRows) {
+                DB::table('lms_assignments')->insert($learningRows);
+            }
+        }
+
+        // --- 18. Employee profile notes --------------------------------------
+        // One private note per employee (the Employee Profile's Notes tab, and
+        // another comment source for the Audit Center). Cleared and rewritten
+        // for this tenant only; the table is one row per tenant+employee.
+        DB::table('s_competency_employee_notes')->where('sub_institute_id', $sid)->delete();
+
+        $profileNotes = [
+            'Strong on the technical cluster; development focus is stakeholder communication.',
+            'Ready for a stretch assignment once the current plan closes.',
+            'Discussed career path in the last 1:1 - keen on the specialist track.',
+            'Needs support scheduling the recertification before the expiry window.',
+        ];
+
+        $noteRows = [];
+        foreach ($employees as $i => $emp) {
+            $noteRows[] = [
+                'sub_institute_id' => $sid,
+                'user_id'          => $emp->id,
+                'note'             => $profileNotes[$i % count($profileNotes)],
+                'created_by'       => 1,
+                'updated_by'       => 1,
+                'created_at'       => (clone $now)->subDays(rand(3, 120)),
+                'updated_at'       => $now,
+            ];
+        }
+        if ($noteRows) {
+            DB::table('s_competency_employee_notes')->insert($noteRows);
+        }
+
+        // --- 19. Activity feed backfill (Audit & Activity Center) -------------
+        $activityCount = $this->backfillActivityLog($sid, $now, $employees);
+
+        $this->command?->info("CompetencySeeder: seeded competency module for sub_institute_id={$sid} ({$activityCount} activity entries).");
+    }
+
+    /**
+     * Rebuild the competency activity feed from the records that actually exist.
+     *
+     * The feed table was added after most of the module's data, so the history
+     * of the frameworks, assessments, certifications, plans, actions, evidence,
+     * career paths, learning assignments and role mappings already in the
+     * database was never captured - leaving the Audit & Activity Center with a
+     * dozen rows to show. Every entry written here is derived from a real row:
+     * its id, its name and its own created_at / updated_at timestamps. Nothing
+     * is invented, so each line in the audit table opens a record that exists.
+     *
+     * Runs last (all sections above have committed) and only ever writes for
+     * $sid, whose feed rows run() already cleared.
+     *
+     * @param  \Illuminate\Support\Collection $employees actors to attribute entries to
+     */
+    private function backfillActivityLog(int $sid, Carbon $now, $employees): int
+    {
+        if ($employees->isEmpty()) {
+            return 0;
+        }
+
+        $actors = $employees->values();
+        $actorCount = $actors->count();
+        $index = 0;
+
+        // Round-robin the actors so the User Actions Log has several people in
+        // it, deterministically rather than at random.
+        $nextActor = function () use ($actors, $actorCount, &$index) {
+            $actor = $actors[$index % $actorCount];
+            $index++;
+
+            $name = trim(($actor->first_name ?? '') . ' ' . ($actor->last_name ?? ''));
+
+            return [
+                'id'   => $actor->id ?? null,
+                'name' => $name !== '' ? $name : ('User ' . ($actor->id ?? '?')),
+            ];
+        };
+
+        $rows = [];
+        $add = function (
+            string $action,
+            string $description,
+            ?string $subjectType,
+            $subjectId,
+            ?string $subjectName,
+            $at,
+            ?array $changes = null
+        ) use (&$rows, $sid, $nextActor, $now) {
+            $actor = $nextActor();
+            $stamp = $at ? Carbon::parse($at) : (clone $now);
+
+            $rows[] = [
+                'sub_institute_id' => $sid,
+                'user_id'          => $actor['id'],
+                'actor_name'       => $actor['name'],
+                'action'           => $action,
+                'description'      => $description,
+                'subject_type'     => $subjectType,
+                'subject_id'       => $subjectId ? (int) $subjectId : null,
+                'subject_name'     => $subjectName !== null ? mb_substr($subjectName, 0, 191) : null,
+                'changes'          => $changes ? json_encode($changes) : null,
+                'created_at'       => $stamp,
+                'updated_at'       => $stamp,
+            ];
+        };
+
+        // 1. Frameworks: created, and published for the ones that went active.
+        foreach (DB::table('s_competency_frameworks')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $fw) {
+            $add('created_framework', 'Created framework "' . $fw->name . '"', 'framework', $fw->id, $fw->name, $fw->created_at);
+
+            if ($fw->status === 'active') {
+                $add(
+                    'published_framework',
+                    'Published framework "' . $fw->name . '"',
+                    'framework',
+                    $fw->id,
+                    $fw->name,
+                    $fw->updated_at,
+                    [['field' => 'status', 'label' => 'Status', 'old' => 'draft', 'new' => 'active']]
+                );
+            }
+        }
+
+        // 2. Assessment cycles + the assessments inside them.
+        foreach (DB::table('s_competency_assessment_cycles')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $cycle) {
+            $add('created_assessment_cycle', 'Created assessment campaign "' . $cycle->name . '"', 'assessment_cycle', $cycle->id, $cycle->name, $cycle->created_at);
+
+            if ($cycle->status === 'closed') {
+                $add(
+                    'completed_assessment_cycle',
+                    'Closed assessment campaign "' . $cycle->name . '"',
+                    'assessment_cycle',
+                    $cycle->id,
+                    $cycle->name,
+                    $cycle->updated_at,
+                    [['field' => 'status', 'label' => 'Status', 'old' => 'active', 'new' => 'closed']]
+                );
+            }
+        }
+
+        foreach (DB::table('s_competency_assessments')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $assessment) {
+            $add('launched_assessment', 'Launched assessment "' . $assessment->title . '"', 'assessment', $assessment->id, $assessment->title, $assessment->created_at);
+
+            if ($assessment->status === 'completed') {
+                $add(
+                    $assessment->review_status === 'reviewed' ? 'approved_assessment' : 'completed_assessment',
+                    ($assessment->review_status === 'reviewed' ? 'Approved' : 'Completed') . ' assessment "' . $assessment->title . '"',
+                    'assessment',
+                    $assessment->id,
+                    $assessment->title,
+                    $assessment->updated_at,
+                    [['field' => 'status', 'label' => 'Status', 'old' => 'in_progress', 'new' => 'completed']]
+                );
+            }
+        }
+
+        // 3. Certifications: recorded, plus verify / expiry state changes.
+        foreach (DB::table('s_competency_certifications')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $cert) {
+            $add('added_certification', 'Added certification "' . $cert->name . '"', 'certification', $cert->id, $cert->name, $cert->created_at);
+
+            if ($cert->verification_status === 'verified') {
+                $add(
+                    'verified_certification',
+                    'Verified certification "' . $cert->name . '"',
+                    'certification',
+                    $cert->id,
+                    $cert->name,
+                    $cert->verified_at ?: $cert->updated_at,
+                    [['field' => 'verification_status', 'label' => 'Verification Status', 'old' => 'pending', 'new' => 'verified']]
+                );
+            } elseif ($cert->verification_status === 'rejected') {
+                $add(
+                    'rejected_certification',
+                    'Rejected certification "' . $cert->name . '"',
+                    'certification',
+                    $cert->id,
+                    $cert->name,
+                    $cert->updated_at,
+                    [['field' => 'verification_status', 'label' => 'Verification Status', 'old' => 'pending', 'new' => 'rejected']]
+                );
+            }
+
+            if ($cert->status === 'revoked') {
+                $add(
+                    'updated_certification',
+                    'Revoked certification "' . $cert->name . '"',
+                    'certification',
+                    $cert->id,
+                    $cert->name,
+                    $cert->updated_at,
+                    [['field' => 'status', 'label' => 'Status', 'old' => 'valid', 'new' => 'revoked']]
+                );
+            }
+
+            // A reviewer note on the credential is a comment on that record.
+            if (!empty($cert->notes)) {
+                // Strip the "[date - author] " prefix addNote() writes so the
+                // feed shows the remark itself.
+                $note = preg_replace('/^\[[^\]]*\]\s*/', '', (string) $cert->notes);
+
+                $add('commented_certification', $note, 'certification', $cert->id, $cert->name, $cert->updated_at);
+            }
+        }
+
+        foreach (DB::table('s_competency_certification_requirements')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $req) {
+            $add('added_certification_requirement', 'Added certification requirement "' . $req->name . '"', 'certification_requirement', $req->id, $req->name, $req->created_at);
+        }
+
+        // 4. Development plans and their action items.
+        $plans = DB::table('s_competency_development_plans')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get()->keyBy('id');
+
+        foreach ($plans as $plan) {
+            $add('created_development_plan', 'Created development plan "' . $plan->title . '"', 'development_plan', $plan->id, $plan->title, $plan->created_at);
+
+            if ($plan->approval_status === 'pending_approval') {
+                $add('submitted_development_plan', 'Submitted development plan "' . $plan->title . '" for approval', 'development_plan', $plan->id, $plan->title, $plan->updated_at);
+            }
+
+            if ($plan->status === 'completed') {
+                $add(
+                    'completed_development_plan',
+                    'Completed development plan "' . $plan->title . '"',
+                    'development_plan',
+                    $plan->id,
+                    $plan->title,
+                    $plan->completed_at ?: $plan->updated_at,
+                    [
+                        ['field' => 'status',   'label' => 'Status',   'old' => 'active', 'new' => 'completed'],
+                        ['field' => 'progress', 'label' => 'Progress', 'old' => '75',     'new' => '100'],
+                    ]
+                );
+            }
+        }
+
+        foreach (DB::table('s_competency_plan_actions')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $action) {
+            $planTitle = $plans[$action->plan_id]->title ?? ('Plan #' . $action->plan_id);
+
+            $add('added_plan_action', 'Added action "' . $action->title . '" to plan "' . $planTitle . '"', 'development_plan', $action->plan_id, $planTitle, $action->created_at);
+
+            if ($action->status === 'completed') {
+                $add(
+                    'completed_plan_action',
+                    'Completed action "' . $action->title . '" on plan "' . $planTitle . '"',
+                    'development_plan',
+                    $action->plan_id,
+                    $planTitle,
+                    $action->completed_at ?: $action->updated_at,
+                    [['field' => 'status', 'label' => 'Status', 'old' => 'in_progress', 'new' => 'completed']]
+                );
+            }
+        }
+
+        // 5. Evidence, career paths, learning assignments, mapping reviews.
+        foreach (DB::table('s_competency_evidence')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $evidence) {
+            $add('added_evidence', 'Added evidence "' . $evidence->title . '"', 'evidence', $evidence->id, $evidence->title, $evidence->created_at);
+        }
+
+        foreach (DB::table('s_competency_career_paths')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $path) {
+            $add('created_career_path', 'Created career path "' . $path->name . '"', 'career_path', $path->id, $path->name, $path->created_at);
+        }
+
+        // Employee profile notes - the module's other first-class comment.
+        $employeeNames = DB::table('tbluser')
+            ->whereIn('id', DB::table('s_competency_employee_notes')->where('sub_institute_id', $sid)->pluck('user_id'))
+            ->get(['id', 'first_name', 'last_name'])
+            ->mapWithKeys(fn ($u) => [
+                $u->id => trim(($u->first_name ?? '') . ' ' . ($u->last_name ?? '')) ?: ('User ' . $u->id),
+            ]);
+
+        foreach (DB::table('s_competency_employee_notes')->where('sub_institute_id', $sid)->get() as $note) {
+            $add(
+                'commented_employee_profile',
+                $note->note,
+                'employee_note',
+                $note->user_id,
+                $employeeNames[$note->user_id] ?? ('User ' . $note->user_id),
+                $note->created_at
+            );
+        }
+
+        $courseNames = DB::table('sub_std_map')->where('sub_institute_id', $sid)->pluck('display_name', 'id');
+
+        foreach (DB::table('lms_assignments')->where('sub_institute_id', $sid)->where('source', 'competency')->whereNull('deleted_at')->get() as $assignment) {
+            $courseName = $courseNames[$assignment->course_id] ?? 'course';
+
+            $add('assigned_learning', 'Assigned "' . $courseName . '" to 1 employee(s)', 'learning_assignment', $assignment->id, $courseName, $assignment->created_at);
+
+            if ($assignment->status === 'Completed') {
+                $add(
+                    'completed_learning',
+                    'Completed learning assignment "' . $courseName . '"',
+                    'learning_assignment',
+                    $assignment->id,
+                    $courseName,
+                    $assignment->updated_at,
+                    [
+                        ['field' => 'status',   'label' => 'Status',   'old' => 'In Progress', 'new' => 'Completed'],
+                        ['field' => 'progress', 'label' => 'Progress', 'old' => '60',          'new' => '100'],
+                    ]
+                );
+            }
+        }
+
+        foreach (DB::table('s_competency_mapping_reviews')->where('sub_institute_id', $sid)->whereNull('deleted_at')->get() as $review) {
+            $add('submitted_mapping_review', 'Submitted role mapping for "' . $review->jobrole . '" for review', 'mapping_review', $review->id, $review->jobrole, $review->created_at);
+
+            if (in_array($review->status, ['approved', 'rejected'], true)) {
+                $add(
+                    $review->status . '_mapping_review',
+                    ucfirst($review->status) . ' role mapping for "' . $review->jobrole . '"',
+                    'mapping_review',
+                    $review->id,
+                    $review->jobrole,
+                    $review->reviewed_at ?: $review->updated_at,
+                    [['field' => 'status', 'label' => 'Review Status', 'old' => 'pending', 'new' => $review->status]]
+                );
+            }
+
+            // The review's note is a genuine comment on that record.
+            if (!empty($review->note)) {
+                $add('commented_mapping_review', $review->note, 'mapping_review', $review->id, $review->jobrole, $review->updated_at);
+            }
+        }
+
+        // 6. Role mappings: a sample of the tenant's real cells, so the Role
+        // Mapping module is represented without writing 50k feed rows.
+        $mappings = DB::table('s_user_skill_jobrole')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->whereNotNull('proficiency_level')
+            ->orderByDesc('id')
+            ->limit(60)
+            ->get(['id', 'jobrole', 'skill', 'proficiency_level', 'created_at', 'updated_at']);
+
+        foreach ($mappings as $cell) {
+            $add(
+                'mapped_role_competency',
+                'Set "' . $cell->skill . '" to level ' . $cell->proficiency_level . ' for "' . $cell->jobrole . '"',
+                'role_mapping',
+                $cell->id,
+                $cell->jobrole . ' - ' . $cell->skill,
+                $cell->created_at ?: $cell->updated_at
+            );
+        }
+
+        // 7. Competency library: the tenant's most recently added competencies.
+        $competencies = DB::table('s_users_skills')
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->where('approve_status', 'Approved')
+            ->orderByDesc('id')
+            ->limit(40)
+            ->get(['id', 'title', 'created_at', 'updated_at']);
+
+        foreach ($competencies as $competency) {
+            $add('created_competency', 'Created competency "' . $competency->title . '"', 'competency', $competency->id, $competency->title, $competency->created_at);
+        }
+
+        // 8. Imports / Exports: the bulk operations that produced the catalog
+        // above. One entry per batch, sized from what is actually in the table.
+        $exportStamps = [7, 21, 44, 70];
+        foreach ($exportStamps as $offset) {
+            $add(
+                'exported_certifications',
+                'Exported ' . DB::table('s_competency_certifications')->where('sub_institute_id', $sid)->whereNull('deleted_at')->count() . ' certification records',
+                'certification',
+                null,
+                'Certification Register',
+                (clone $now)->subDays($offset)
+            );
+        }
+
+        $add(
+            'imported_competencies',
+            'Imported ' . $competencies->count() . ' competencies from spreadsheet',
+            'competency',
+            null,
+            'Competency_Library_Import.xlsx',
+            (clone $now)->subDays(35)
+        );
+
+        $add(
+            'imported_role_mappings',
+            'Imported ' . $mappings->count() . ' role mapping rows',
+            'role_mapping',
+            null,
+            'Role_Mapping_Matrix.csv',
+            (clone $now)->subDays(18)
+        );
+
+        // Chunked: the feed can run to a few thousand rows on a full tenant.
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('s_competency_activity_log')->insert($chunk);
+        }
+
+        return count($rows);
+    }
+
+    /**
+     * Seniority rank implied by a job title. Ordered most-senior first and the
+     * first match wins, so "Assistant Manager" is checked before "Manager" and
+     * "Senior Manager" before either "Senior" or "Manager".
+     */
+    private function rankOf(string $name): ?int
+    {
+        $tiers = [
+            7 => '/\b(chief|president|partner|director|vice\s*president|vp|head)\b/i',
+            6 => '/\b(senior\s+manager|general\s+manager|principal)\b/i',
+            4 => '/\b(assistant\s+manager|deputy|supervisor|team\s+lead|lead)\b/i',
+            5 => '/\b(manager)\b/i',
+            3 => '/\b(senior|specialist)\b/i',
+            2 => '/\b(executive|associate|officer|analyst|engineer|consultant|coordinator|technician)\b/i',
+            1 => '/\b(assistant|trainee|intern|apprentice|junior)\b/i',
+        ];
+
+        foreach ($tiers as $rank => $pattern) {
+            if (preg_match($pattern, $name)) {
+                return $rank;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Group the tenant's job roles into per-department seniority ladders,
+     * keeping only departments that yield at least three distinct rungs.
+     *
+     * @return array<int, array{department:string, department_id:?int, steps:array, peers:array}>
+     */
+    private function buildLadders(int $sid): array
+    {
+        $roles = DB::table('s_user_jobrole')
+            ->where('sub_institute_id', $sid)->whereNull('deleted_at')
+            ->whereNotNull('department')->where('department', '!=', '')
+            ->whereNotNull('jobrole')->where('jobrole', '!=', '')
+            ->get(['id', 'jobrole', 'job_level', 'department', 'department_id', 'related_jobrole']);
+
+        $roleIdByName = [];
+        foreach ($roles as $role) {
+            $roleIdByName[$role->jobrole] ??= (int) $role->id;
+        }
+
+        $byDepartment = [];
+        foreach ($roles as $role) {
+            $byDepartment[$role->department][] = $role;
+        }
+
+        $ladders = [];
+        foreach ($byDepartment as $department => $departmentRoles) {
+            $steps = [];
+            $sameRank = [];
+
+            foreach ($departmentRoles as $role) {
+                $rank = $this->rankOf($role->jobrole);
+                if ($rank === null) {
+                    continue;
+                }
+                $sameRank[$rank][] = (int) $role->id;
+                $steps[$rank] ??= $role;   // one representative role per rung
+            }
+
+            if (count($steps) < 3) {
+                continue;
+            }
+
+            ksort($steps);
+
+            // Lateral peers: same-rung colleagues, plus related_jobrole entries
+            // that resolve to a real role in this tenant.
+            $peers = [];
+            foreach ($steps as $rank => $step) {
+                $candidates = array_values(array_diff($sameRank[$rank], [(int) $step->id]));
+
+                foreach (array_filter(array_map('trim', explode(',', (string) $step->related_jobrole))) as $name) {
+                    if (isset($roleIdByName[$name]) && $roleIdByName[$name] !== (int) $step->id) {
+                        $candidates[] = $roleIdByName[$name];
+                    }
+                }
+
+                $peers[(int) $step->id] = array_values(array_unique($candidates));
+            }
+
+            $ladders[] = [
+                'department'    => $department,
+                'department_id' => $steps[array_key_first($steps)]->department_id,
+                'steps'         => $steps,
+                'peers'         => $peers,
+            ];
+        }
+
+        return $ladders;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,21 @@ use App\Http\Controllers\libraries\jobroleskillcontroller;
 use App\Http\Controllers\HRMS\HrmsController;
 use App\Http\Controllers\Api\CompetencyDashboardController;
 use App\Http\Controllers\Api\CompetencyDashboard\CompetencyDashboardController as SubCompetencyDashboardController;
+use App\Http\Controllers\Api\Competency\CommandCenterController as CompetencyCommandCenterController;
+use App\Http\Controllers\Api\Competency\CompetencyController as CompetencyCrudController;
+use App\Http\Controllers\Api\Competency\FrameworkController as CompetencyFrameworkController;
+use App\Http\Controllers\Api\Competency\AssessmentController as CompetencyAssessmentController;
+use App\Http\Controllers\Api\Competency\AssessmentCycleController as CompetencyAssessmentCycleController;
+use App\Http\Controllers\Api\Competency\EmployeeCompetencyProfileController;
+use App\Http\Controllers\Api\Competency\CertificationController as CompetencyCertificationController;
+use App\Http\Controllers\Api\Competency\CertificationRequirementController as CompetencyCertificationRequirementController;
+use App\Http\Controllers\Api\Competency\DevelopmentPlanController as CompetencyDevelopmentPlanController;
+use App\Http\Controllers\Api\Competency\StudioController as CompetencyStudioController;
+use App\Http\Controllers\Api\Competency\RoleMappingController as CompetencyRoleMappingController;
+use App\Http\Controllers\Api\Competency\MappingReviewController as CompetencyMappingReviewController;
+use App\Http\Controllers\Api\Competency\CareerPathController as CompetencyCareerPathController;
+use App\Http\Controllers\Api\Competency\LearningAssignmentController as CompetencyLearningAssignmentController;
+use App\Http\Controllers\Api\Competency\AuditController as CompetencyAuditController;
 use App\Http\Controllers\Api\DBController;
 use App\Http\Controllers\talent\talent_jobpostingcontroller;
 use App\Http\Controllers\talent\talent_jobapplicationcontroller;
@@ -162,6 +177,192 @@ Route::get('/competency/health-radar', [SubCompetencyDashboardController::class,
 Route::get('/competency/skills-management-funnel', [SubCompetencyDashboardController::class, 'getSkillsManagementFunnel']);
 Route::get('/competency/alignment', [SubCompetencyDashboardController::class, 'getAlignment']);
 
+/*
+| Competency Command Center + domain CRUD (token authenticated, tenant scoped
+| via App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext).
+| Additive - does not touch the read-only /competency/* analytics routes above.
+*/
+Route::get('/competency/command-center', [CompetencyCommandCenterController::class, 'index']);
+Route::get('/competency/command-center/filters', [CompetencyCommandCenterController::class, 'filters']);
+
+Route::get('/competency/assessment-cycles', [CompetencyAssessmentCycleController::class, 'index']);
+Route::post('/competency/assessment-cycles', [CompetencyAssessmentCycleController::class, 'store']);
+Route::get('/competency/assessment-cycles/metrics', [CompetencyAssessmentCycleController::class, 'metrics']);
+Route::get('/competency/assessment-cycles/participant-ratings', [CompetencyAssessmentCycleController::class, 'participantRatings']);
+Route::get('/competency/assessment-cycles/calibration', [CompetencyAssessmentCycleController::class, 'calibration']);
+Route::get('/competency/assessment-cycles/approvals', [CompetencyAssessmentCycleController::class, 'approvals']);
+Route::get('/competency/assessment-cycles/closed', [CompetencyAssessmentCycleController::class, 'closed']);
+Route::put('/competency/assessment-cycles/assessments/{id}/review', [CompetencyAssessmentCycleController::class, 'reviewAssessment'])->whereNumber('id');
+// "View Configuration" - declared BEFORE /{id} so the word is not read as an id.
+Route::get('/competency/assessment-cycles/configuration', [CompetencyAssessmentCycleController::class, 'configuration']);
+Route::put('/competency/assessment-cycles/configuration', [CompetencyAssessmentCycleController::class, 'saveConfiguration']);
+Route::get('/competency/assessment-cycles/{id}/participants', [CompetencyAssessmentCycleController::class, 'participants'])->whereNumber('id');
+// Campaign detail panel: Overview / Edit / Ratings / Calibration / Audit Trail.
+Route::get('/competency/assessment-cycles/{id}/ratings', [CompetencyAssessmentCycleController::class, 'ratings'])->whereNumber('id');
+Route::get('/competency/assessment-cycles/{id}/calibration-queue', [CompetencyAssessmentCycleController::class, 'calibrationQueue'])->whereNumber('id');
+Route::get('/competency/assessment-cycles/{id}/audit-trail', [CompetencyAssessmentCycleController::class, 'auditTrail'])->whereNumber('id');
+Route::get('/competency/assessment-cycles/{id}', [CompetencyAssessmentCycleController::class, 'show'])->whereNumber('id');
+Route::put('/competency/assessment-cycles/{id}', [CompetencyAssessmentCycleController::class, 'update'])->whereNumber('id');
+
+Route::get('/competency/employee-profiles/{id}', [EmployeeCompetencyProfileController::class, 'show'])->whereNumber('id');
+Route::get('/competency/employee-profiles/{id}/available-skills', [EmployeeCompetencyProfileController::class, 'availableSkills'])->whereNumber('id');
+Route::post('/competency/employee-profiles/{id}/skills', [EmployeeCompetencyProfileController::class, 'addSkill'])->whereNumber('id');
+Route::put('/competency/employee-profiles/{id}/skills/{matrixId}', [EmployeeCompetencyProfileController::class, 'updateSkill'])->whereNumber('id')->whereNumber('matrixId');
+Route::get('/competency/employee-profiles/{id}/skills/{skillId}/history', [EmployeeCompetencyProfileController::class, 'skillHistory'])->whereNumber('id')->whereNumber('skillId');
+Route::get('/competency/employee-profiles/{id}/notes', [EmployeeCompetencyProfileController::class, 'notes'])->whereNumber('id');
+Route::put('/competency/employee-profiles/{id}/notes', [EmployeeCompetencyProfileController::class, 'saveNotes'])->whereNumber('id');
+Route::get('/competency/employee-profiles/{id}/certifications', [EmployeeCompetencyProfileController::class, 'certifications'])->whereNumber('id');
+Route::get('/competency/employee-profiles/{id}/development-plans', [EmployeeCompetencyProfileController::class, 'developmentPlans'])->whereNumber('id');
+Route::get('/competency/employee-profiles/{id}/evidence', [EmployeeCompetencyProfileController::class, 'evidence'])->whereNumber('id');
+Route::post('/competency/employee-profiles/{id}/evidence', [EmployeeCompetencyProfileController::class, 'storeEvidence'])->whereNumber('id');
+Route::delete('/competency/employee-profiles/{id}/evidence/{evidenceId}', [EmployeeCompetencyProfileController::class, 'deleteEvidence'])->whereNumber('id')->whereNumber('evidenceId');
+Route::get('/competency/employee-profiles/{id}/career-path', [EmployeeCompetencyProfileController::class, 'careerPath'])->whereNumber('id');
+
+Route::get('/competency/competencies', [CompetencyCrudController::class, 'index']);
+Route::post('/competency/competencies', [CompetencyCrudController::class, 'store']);
+Route::delete('/competency/competencies/{id}', [CompetencyCrudController::class, 'destroy'])->whereNumber('id');
+
+Route::get('/competency/frameworks', [CompetencyFrameworkController::class, 'index']);
+Route::post('/competency/frameworks', [CompetencyFrameworkController::class, 'store']);
+Route::delete('/competency/frameworks/{id}', [CompetencyFrameworkController::class, 'destroy'])->whereNumber('id');
+
+Route::get('/competency/assessments', [CompetencyAssessmentController::class, 'index']);
+Route::post('/competency/assessments', [CompetencyAssessmentController::class, 'store']);
+Route::delete('/competency/assessments/{id}', [CompetencyAssessmentController::class, 'destroy'])->whereNumber('id');
+
+Route::get('/competency/certifications', [CompetencyCertificationController::class, 'index']);
+Route::post('/competency/certifications', [CompetencyCertificationController::class, 'store']);
+Route::delete('/competency/certifications/{id}', [CompetencyCertificationController::class, 'destroy'])->whereNumber('id');
+
+Route::get('/competency/development-plans', [CompetencyDevelopmentPlanController::class, 'index']);
+Route::post('/competency/development-plans', [CompetencyDevelopmentPlanController::class, 'store']);
+Route::delete('/competency/development-plans/{id}', [CompetencyDevelopmentPlanController::class, 'destroy'])->whereNumber('id');
+
+/*
+| Development & Career Path Workspace (token authenticated, tenant scoped).
+| Additive on top of the three development-plan routes above, which keep their
+| existing contract. Reuses s_skill_matrix + s_user_skill_jobrole for gaps,
+| s_competency_activity_log for history, career_journey + s_user_jobrole for the
+| progression graph and sub_std_map + lms_assignments for learning; adds
+| s_competency_plan_actions and s_competency_career_paths/_steps.
+*/
+
+// Static segments first so they cannot be swallowed by /{id}.
+Route::get('/competency/development-plans/metrics', [CompetencyDevelopmentPlanController::class, 'metrics']);
+Route::get('/competency/development-plans/owners', [CompetencyDevelopmentPlanController::class, 'owners']);
+Route::get('/competency/employee-options', [CompetencyDevelopmentPlanController::class, 'employees']);
+
+Route::get('/competency/development-plans/{id}', [CompetencyDevelopmentPlanController::class, 'show'])->whereNumber('id');
+Route::put('/competency/development-plans/{id}', [CompetencyDevelopmentPlanController::class, 'update'])->whereNumber('id');
+Route::get('/competency/development-plans/{id}/gaps', [CompetencyDevelopmentPlanController::class, 'gaps'])->whereNumber('id');
+Route::get('/competency/development-plans/{id}/history', [CompetencyDevelopmentPlanController::class, 'history'])->whereNumber('id');
+Route::get('/competency/development-plans/{id}/actions', [CompetencyDevelopmentPlanController::class, 'actions'])->whereNumber('id');
+Route::post('/competency/development-plans/{id}/actions', [CompetencyDevelopmentPlanController::class, 'storeAction'])->whereNumber('id');
+Route::put('/competency/development-plans/{id}/actions/{actionId}', [CompetencyDevelopmentPlanController::class, 'updateAction'])->whereNumber('id')->whereNumber('actionId');
+Route::delete('/competency/development-plans/{id}/actions/{actionId}', [CompetencyDevelopmentPlanController::class, 'destroyAction'])->whereNumber('id')->whereNumber('actionId');
+
+// Named career paths + the Career Path Explorer.
+Route::get('/competency/career-paths/explorer', [CompetencyCareerPathController::class, 'explorer']);
+Route::get('/competency/career-paths/role-options', [CompetencyCareerPathController::class, 'roleOptions']);
+Route::get('/competency/career-paths', [CompetencyCareerPathController::class, 'index']);
+Route::post('/competency/career-paths', [CompetencyCareerPathController::class, 'store']);
+Route::get('/competency/career-paths/{id}', [CompetencyCareerPathController::class, 'show'])->whereNumber('id');
+Route::put('/competency/career-paths/{id}', [CompetencyCareerPathController::class, 'update'])->whereNumber('id');
+Route::delete('/competency/career-paths/{id}', [CompetencyCareerPathController::class, 'destroy'])->whereNumber('id');
+
+// Learning assignments (lms_assignments rows tagged source='competency').
+Route::get('/competency/learning-assignments/courses', [CompetencyLearningAssignmentController::class, 'courses']);
+Route::get('/competency/learning-assignments', [CompetencyLearningAssignmentController::class, 'index']);
+Route::post('/competency/learning-assignments', [CompetencyLearningAssignmentController::class, 'store']);
+Route::put('/competency/learning-assignments/{id}', [CompetencyLearningAssignmentController::class, 'update'])->whereNumber('id');
+Route::delete('/competency/learning-assignments/{id}', [CompetencyLearningAssignmentController::class, 'destroy'])->whereNumber('id');
+
+/*
+| Framework & Role Mapping Studio (token authenticated, tenant scoped).
+| Additive: reuses existing tables (s_users_skills, s_user_jobrole,
+| s_user_skill_jobrole, s_proficiency_levels, s_competency_frameworks/_items)
+| plus two new studio tables (s_competency_framework_weights, _mapping_reviews).
+*/
+Route::get('/competency/studio/summary', [CompetencyStudioController::class, 'summary']);
+Route::get('/competency/studio/framework-structure', [CompetencyStudioController::class, 'frameworkStructure']);
+Route::get('/competency/studio/proficiency-scale', [CompetencyStudioController::class, 'proficiencyScale']);
+Route::post('/competency/studio/proficiency-scale', [CompetencyStudioController::class, 'storeLevel']);
+Route::put('/competency/studio/proficiency-scale/{id}', [CompetencyStudioController::class, 'updateLevel'])->whereNumber('id');
+Route::delete('/competency/studio/proficiency-scale/{id}', [CompetencyStudioController::class, 'deleteLevel'])->whereNumber('id');
+Route::get('/competency/studio/weights', [CompetencyStudioController::class, 'weights']);
+Route::put('/competency/studio/weights', [CompetencyStudioController::class, 'saveWeights']);
+// Scoring rules behind the weights (s_competency_settings, scope='weighting').
+Route::get('/competency/studio/weighting-config', [CompetencyStudioController::class, 'weightingConfig']);
+Route::put('/competency/studio/weighting-config', [CompetencyStudioController::class, 'saveWeightingConfig']);
+
+// Framework show / update / clone / items / weighting (list/create/delete are above).
+Route::get('/competency/frameworks/{id}', [CompetencyFrameworkController::class, 'show'])->whereNumber('id');
+Route::put('/competency/frameworks/{id}', [CompetencyFrameworkController::class, 'update'])->whereNumber('id');
+Route::post('/competency/frameworks/{id}/clone', [CompetencyFrameworkController::class, 'clone'])->whereNumber('id');
+Route::get('/competency/frameworks/{id}/items', [CompetencyFrameworkController::class, 'items'])->whereNumber('id');
+Route::post('/competency/frameworks/{id}/items', [CompetencyFrameworkController::class, 'storeItem'])->whereNumber('id');
+Route::delete('/competency/frameworks/{id}/items/{itemId}', [CompetencyFrameworkController::class, 'destroyItem'])->whereNumber('id')->whereNumber('itemId');
+Route::get('/competency/frameworks/{id}/weights', [CompetencyFrameworkController::class, 'weights'])->whereNumber('id');
+Route::put('/competency/frameworks/{id}/weights', [CompetencyFrameworkController::class, 'saveWeights'])->whereNumber('id');
+
+// Role mapping matrix (cells live on s_user_skill_jobrole).
+Route::get('/competency/role-mapping/roles', [CompetencyRoleMappingController::class, 'roles']);
+Route::get('/competency/role-mapping/matrix', [CompetencyRoleMappingController::class, 'matrix']);
+Route::put('/competency/role-mapping/cell', [CompetencyRoleMappingController::class, 'upsertCell']);
+Route::delete('/competency/role-mapping/cell', [CompetencyRoleMappingController::class, 'deleteCell']);
+
+// Mapping-change approval workflow.
+Route::get('/competency/mapping-reviews', [CompetencyMappingReviewController::class, 'index']);
+Route::post('/competency/mapping-reviews', [CompetencyMappingReviewController::class, 'store']);
+Route::put('/competency/mapping-reviews/{id}', [CompetencyMappingReviewController::class, 'update'])->whereNumber('id');
+Route::post('/competency/mapping-reviews/bulk-approve', [CompetencyMappingReviewController::class, 'bulkApprove']);
+
+/*
+| Certification & Compliance Center (token authenticated, tenant scoped).
+| Additive on top of the three certification routes above, which keep their
+| paths and response envelope. Reads/writes s_competency_certifications, the
+| new s_competency_certification_requirements policy table, the shared
+| s_competency_evidence table for documents and s_competency_activity_log for
+| history. Static segments are declared BEFORE the /{id} routes so the numeric
+| show/update route cannot swallow metrics / filters / export / bulk.
+*/
+Route::get('/competency/certifications/metrics', [CompetencyCertificationController::class, 'metrics']);
+Route::get('/competency/certifications/filters', [CompetencyCertificationController::class, 'filters']);
+Route::get('/competency/certifications/export', [CompetencyCertificationController::class, 'export']);
+Route::post('/competency/certifications/bulk', [CompetencyCertificationController::class, 'bulk']);
+
+Route::get('/competency/certifications/{id}', [CompetencyCertificationController::class, 'show'])->whereNumber('id');
+Route::put('/competency/certifications/{id}', [CompetencyCertificationController::class, 'update'])->whereNumber('id');
+Route::post('/competency/certifications/{id}/notes', [CompetencyCertificationController::class, 'addNote'])->whereNumber('id');
+Route::get('/competency/certifications/{id}/compliance', [CompetencyCertificationController::class, 'compliance'])->whereNumber('id');
+Route::get('/competency/certifications/{id}/requirements', [CompetencyCertificationController::class, 'requirements'])->whereNumber('id');
+Route::get('/competency/certifications/{id}/history', [CompetencyCertificationController::class, 'history'])->whereNumber('id');
+Route::get('/competency/certifications/{id}/documents', [CompetencyCertificationController::class, 'documents'])->whereNumber('id');
+Route::post('/competency/certifications/{id}/documents', [CompetencyCertificationController::class, 'storeDocument'])->whereNumber('id');
+Route::delete('/competency/certifications/{id}/documents/{documentId}', [CompetencyCertificationController::class, 'destroyDocument'])->whereNumber('id')->whereNumber('documentId');
+
+// Certification requirements - the "which role must hold what" policy master.
+Route::get('/competency/certification-requirements', [CompetencyCertificationRequirementController::class, 'index']);
+Route::post('/competency/certification-requirements', [CompetencyCertificationRequirementController::class, 'store']);
+Route::put('/competency/certification-requirements/{id}', [CompetencyCertificationRequirementController::class, 'update'])->whereNumber('id');
+Route::delete('/competency/certification-requirements/{id}', [CompetencyCertificationRequirementController::class, 'destroy'])->whereNumber('id');
+
+/*
+| Audit & Activity Center (token authenticated, tenant scoped).
+| Read-only over s_competency_activity_log - the feed every competency
+| controller already writes to via ResolvesCompetencyContext - plus
+| tbl_user_journey_logs for the User Actions Log tab's screen-access history.
+| The only write is the export event the export endpoint logs about itself.
+| Static segments are declared BEFORE /{id} so user-actions is not swallowed.
+*/
+Route::get('/competency/audit/metrics', [CompetencyAuditController::class, 'metrics']);
+Route::get('/competency/audit/filters', [CompetencyAuditController::class, 'filters']);
+Route::get('/competency/audit/export', [CompetencyAuditController::class, 'export']);
+Route::get('/competency/audit/user-actions', [CompetencyAuditController::class, 'userActions']);
+Route::get('/competency/audit/user-actions/{userId}', [CompetencyAuditController::class, 'userActivity'])->whereNumber('userId');
+Route::get('/competency/audit', [CompetencyAuditController::class, 'index']);
+Route::get('/competency/audit/{id}', [CompetencyAuditController::class, 'show'])->whereNumber('id');
+
 //HRIT dashboard
 Route::get('/attendance-weekly', [AttendanceApiController::class, 'weeklySummary']);
 Route::get('/KPI-HRITDashboard', [AttendanceApiController::class, 'KPI']);
@@ -281,6 +482,20 @@ Route::get('/index', [buildwithAIController::class, 'index']);
 
 Route::resource('gamma-api', GammaApiController::class);
 Route::get('gamma-api/sub-institute/{subInstituteId}', [GammaApiController::class, 'getBySubInstituteId']);
+
+// Competency Library JSON API (additive; a competency == an approved skill on
+// s_users_skills). Registered BEFORE the skill_library resource so these paths
+// are not swallowed by the resource's /skill_library/{id} show route.
+Route::get('skill_library/competency-list', [skillLibraryController::class, 'competencyLibraryIndex']);
+Route::get('skill_library/competency-export', [skillLibraryController::class, 'competencyLibraryExport']);
+Route::post('skill_library/competency-import', [skillLibraryController::class, 'competencyLibraryImport']);
+Route::get('skill_library/competency/{id}/detail', [skillLibraryController::class, 'competencyLibraryDetail'])->whereNumber('id');
+Route::post('skill_library/competency/{id}/clone', [skillLibraryController::class, 'competencyLibraryClone'])->whereNumber('id');
+Route::put('skill_library/competency/{id}/archive', [skillLibraryController::class, 'competencyLibraryArchive'])->whereNumber('id');
+Route::get('skill_library/competency/{id}', [skillLibraryController::class, 'competencyLibraryShow'])->whereNumber('id');
+Route::post('skill_library/competency', [skillLibraryController::class, 'competencyLibraryStore']);
+Route::put('skill_library/competency/{id}', [skillLibraryController::class, 'competencyLibraryUpdate'])->whereNumber('id');
+Route::delete('skill_library/competency/{id}', [skillLibraryController::class, 'competencyLibraryDestroy'])->whereNumber('id');
 
 Route::resource('skill_library', skillLibraryController::class);
 Route::get('/positions', [InterviewController::class, 'getPositions']);


### PR DESCRIPTION
Add all necessary code for the competency management module:
- All Eloquent models for competency workflows including assessments, certifications, development plans, and career paths
- Database migrations for new tables and schema updates across existing tables
- API controllers for competency library, assessment management, command center dashboard, and module settings
- Shared traits for competency context resolution and settings handling
- A minor adjustment to the filesystems config to support DigitalOcean Spaces URL resolution