### PR TITLE
Milan 2

### DIFF
--- a/app/Http/Controllers/Api/Competency/LibraryController.php
+++ b/app/Http/Controllers/Api/Competency/LibraryController.php
@@ -999,6 +999,97 @@ class LibraryController extends Controller
             : $this->badRequest('Unknown attribute type.', 404);
     }
 
+    /**
+     * Where a knowledge / ability / attitude / behaviour item is actually used.
+     *
+     * The previous app's detail popup declared state for exactly this - which
+     * skills reference the item, at which proficiency levels, and which job
+     * roles inherit it - and then never fetched any of it, so those panels were
+     * permanently empty. The data exists: s_skill_knowledge_ability joins a
+     * classification item back to the skills that list it.
+     *
+     * Matching is by `classification_item` against the item's title, because
+     * that join carries the text rather than a foreign key.
+     */
+    public function usageKasa(Request $request, $type, $id)
+    {
+        $resolved = $this->kasaType($type);
+
+        if (!$resolved) {
+            return $this->badRequest('Unknown attribute type.', 404);
+        }
+
+        $context = $this->competencyContext($request);
+        if (!is_array($context)) {
+            return $context;
+        }
+
+        $sid = $context['sub_institute_id'];
+        $config = self::RESOURCES[$resolved];
+
+        $item = DB::table($config['table'])
+            ->where('id', (int) $id)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (!$item) {
+            return $this->badRequest('Not found.', 404);
+        }
+
+        $title = trim((string) ($item->{$config['title']} ?? ''));
+
+        // A blank title cannot be matched against, and matching on '' would
+        // return every unclassified row in the tenant.
+        if ($title === '') {
+            return $this->ok('Usage', [
+                'item'         => $item,
+                'skills'       => [],
+                'jobroles'     => [],
+                'levels'       => [],
+                'skill_count'  => 0,
+            ]);
+        }
+
+        $links = DB::table('s_skill_knowledge_ability as ska')
+            ->join('s_users_skills as s', 's.id', '=', 'ska.skill_id')
+            ->where('ska.classification', $resolved)
+            ->where('ska.classification_item', $title)
+            ->where('ska.sub_institute_id', $sid)
+            ->whereNull('ska.deleted_at')
+            ->whereNull('s.deleted_at')
+            ->orderBy('s.title')
+            ->get([
+                'ska.id',
+                'ska.skill_id',
+                'ska.proficiency_level',
+                'ska.classification_category',
+                'ska.classification_sub_category',
+                's.title as skill_title',
+                's.category as skill_category',
+                's.sub_category as skill_sub_category',
+                's.department as skill_department',
+            ]);
+
+        // Job roles reached through those skills - the item's real blast radius.
+        $skillTitles = $links->pluck('skill_title')->filter()->unique()->values()->all();
+
+        $jobroles = $skillTitles === [] ? collect() : DB::table('s_user_skill_jobrole')
+            ->whereIn('skill', $skillTitles)
+            ->where('sub_institute_id', $sid)
+            ->whereNull('deleted_at')
+            ->orderBy('jobrole')
+            ->get(['id', 'jobrole', 'skill', 'proficiency_level', 'proficiency_description', 'track', 'sector']);
+
+        return $this->ok('Usage', [
+            'item'        => $item,
+            'skills'      => $links,
+            'jobroles'    => $jobroles,
+            'levels'      => $links->pluck('proficiency_level')->filter()->unique()->sort()->values(),
+            'skill_count' => $links->count(),
+        ]);
+    }
+
     public function updateKasa(Request $request, $type, $id)
     {
         $resolved = $this->kasaType($type);

--- a/app/Http/Controllers/Api/Competency/LibraryController.php
+++ b/app/Http/Controllers/Api/Competency/LibraryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Competency;
 use App\Http\Controllers\Api\Competency\Concerns\ResolvesCompetencyContext;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 
@@ -617,6 +618,9 @@ class LibraryController extends Controller
             (string) $data[$resource['title']]
         );
 
+        // Counts and dropdown options are cached; a write makes them stale.
+        $this->forgetLibraryMeta((int) $context['sub_institute_id']);
+
         return $this->ok($resource['label'] . ' created successfully', ['id' => (int) $id]);
     }
 
@@ -700,6 +704,9 @@ class LibraryController extends Controller
             $changes
         );
 
+        // Counts and dropdown options are cached; a write makes them stale.
+        $this->forgetLibraryMeta((int) $context['sub_institute_id']);
+
         return $this->ok($resource['label'] . ' updated successfully', ['id' => $id]);
     }
 
@@ -740,6 +747,9 @@ class LibraryController extends Controller
             $id,
             $name
         );
+
+        // Counts and dropdown options are cached; a write makes them stale.
+        $this->forgetLibraryMeta((int) $context['sub_institute_id']);
 
         return $this->ok($resource['label'] . ' deleted successfully', ['id' => $id]);
     }
@@ -1409,6 +1419,9 @@ class LibraryController extends Controller
             $renamingSub ? $sub : $category
         );
 
+        // Counts and dropdown options are cached; a write makes them stale.
+        $this->forgetLibraryMeta((int) $context['sub_institute_id']);
+
         return $this->ok('Taxonomy updated successfully', ['affected' => $affected]);
     }
 
@@ -1674,6 +1687,43 @@ class LibraryController extends Controller
 
         $sid = $context['sub_institute_id'];
 
+        // The database this talks to is remote: a bare `SELECT 1` costs about
+        // 400ms, so the cost of this endpoint is round trips, not rows. It
+        // used to make thirteen of them and take roughly four seconds.
+        //
+        // Cached on local disk rather than the default store, because the
+        // default store is `database` - the same remote server - so caching
+        // there would just swap thirteen slow round trips for one.
+        //
+        // Writes call forgetLibraryMeta(), so the TTL is only a backstop for
+        // rows changed outside this controller.
+        return Cache::store('file')->remember(
+            self::metaCacheKey($sid),
+            now()->addMinutes(10),
+            fn () => $this->buildMeta($sid),
+        );
+    }
+
+    /** Cache key for one tenant's library metadata. */
+    private static function metaCacheKey(int $sid): string
+    {
+        return "competency:library:meta:{$sid}";
+    }
+
+    /**
+     * Drop a tenant's cached metadata.
+     *
+     * Called after every library write, so the tab counts and dropdown options
+     * reflect the change on the next read instead of after the TTL.
+     */
+    private function forgetLibraryMeta(int $sid): void
+    {
+        Cache::store('file')->forget(self::metaCacheKey($sid));
+    }
+
+    /** @return \Illuminate\Http\JsonResponse */
+    private function buildMeta(int $sid)
+    {
         $jobroleRows = DB::table('s_user_jobrole')
             ->where('sub_institute_id', $sid)
             ->whereNull('deleted_at')
@@ -1693,39 +1743,36 @@ class LibraryController extends Controller
         }
         ksort($byDepartment);
 
-        $proficiency = DB::table('s_users_skills')
-            ->where('sub_institute_id', $sid)
-            ->whereNull('deleted_at')
-            ->whereNotNull('proficiency_level')
-            ->where('proficiency_level', '!=', '')
-            ->distinct()
-            ->orderBy('proficiency_level')
-            ->pluck('proficiency_level');
+        // Four DISTINCT lists in one round trip. They are unrelated columns
+        // on three tables, so a UNION of (bucket, value) pairs is the only way
+        // to ask for them together; the caller splits them back apart.
+        $optionRows = DB::select(
+            "  SELECT 'proficiency' AS bucket, proficiency_level AS value FROM s_users_skills"
+            . "   WHERE sub_institute_id = ? AND deleted_at IS NULL"
+            . "     AND proficiency_level IS NOT NULL AND proficiency_level <> ''"
+            . " UNION SELECT 'department', department FROM s_users_skills"
+            . "   WHERE sub_institute_id = ? AND deleted_at IS NULL"
+            . "     AND department IS NOT NULL AND department <> ''"
+            . " UNION SELECT 'invisible_type', type FROM s_invisible_library"
+            . "   WHERE type IS NOT NULL AND type <> ''"
+            . " UNION SELECT 'task_type', task_type FROM s_user_jobrole_task"
+            . "   WHERE sub_institute_id = ? AND deleted_at IS NULL"
+            . "     AND task_type IS NOT NULL AND task_type <> ''"
+            . " ORDER BY bucket, value",
+            [$sid, $sid, $sid]
+        );
 
-        $departments = DB::table('s_users_skills')
-            ->where('sub_institute_id', $sid)
-            ->whereNull('deleted_at')
-            ->whereNotNull('department')
-            ->where('department', '!=', '')
-            ->distinct()
-            ->orderBy('department')
-            ->pluck('department');
+        $buckets = ['proficiency' => [], 'department' => [], 'invisible_type' => [], 'task_type' => []];
+        foreach ($optionRows as $row) {
+            if (array_key_exists($row->bucket, $buckets)) {
+                $buckets[$row->bucket][] = $row->value;
+            }
+        }
 
-        $invisibleTypes = DB::table('s_invisible_library')
-            ->whereNotNull('type')
-            ->where('type', '!=', '')
-            ->distinct()
-            ->orderBy('type')
-            ->pluck('type');
-
-        $taskTypes = DB::table('s_user_jobrole_task')
-            ->where('sub_institute_id', $sid)
-            ->whereNull('deleted_at')
-            ->whereNotNull('task_type')
-            ->where('task_type', '!=', '')
-            ->distinct()
-            ->orderBy('task_type')
-            ->pluck('task_type');
+        $proficiency = $buckets['proficiency'];
+        $departments = $buckets['department'];
+        $invisibleTypes = $buckets['invisible_type'];
+        $taskTypes = $buckets['task_type'];
 
         return $this->ok('Library metadata fetched successfully', [
             'departments'          => $departments,
@@ -1737,18 +1784,68 @@ class LibraryController extends Controller
         ]);
     }
 
-    /** Row counts per tab, for the badges on the tab strip. */
+    /**
+     * Row counts per tab, for the badges on the tab strip.
+     *
+     * Built as one UNION ALL rather than a count per resource. Eight separate
+     * COUNT queries is eight round trips, and against a remote database that
+     * is roughly two and a half seconds spent almost entirely on the wire -
+     * the largest table here is 85k rows, so none of it is query time.
+     *
+     * The WHERE clauses are assembled from the same RESOURCES config the rest
+     * of the controller uses, so a new tab is counted without touching this.
+     */
     private function libraryCounts(int $sid): array
     {
-        $counts = [];
+        $parts = [];
+        $bindings = [];
 
         foreach (self::RESOURCES as $type => $resource) {
-            $counts[$type] = $this->baseQuery($resource, $sid)
-                ->whereNotNull($resource['title'])
-                ->where($resource['title'], '!=', '')
-                ->count();
+            $where = [];
+            // The bucket label is the first placeholder in this SELECT, so its
+            // binding has to lead the resource's own bindings.
+            $partBindings = [$type];
+
+            if ($resource['tenant'] === 'shared') {
+                // Platform rows have no owner and are visible to everyone.
+                $where[] = '(sub_institute_id IS NULL OR sub_institute_id = ?)';
+                $partBindings[] = $sid;
+            } elseif ($resource['tenant']) {
+                $where[] = 'sub_institute_id = ?';
+                $partBindings[] = $sid;
+            }
+
+            if (!empty($resource['soft'])) {
+                $where[] = 'deleted_at IS NULL';
+            }
+
+            // Placeholder rows carry no title and are not real library entries.
+            $title = $resource['title'];
+            $where[] = "`{$title}` IS NOT NULL";
+            $where[] = "`{$title}` <> ''";
+
+            $parts[] = sprintf(
+                "SELECT ? AS bucket, COUNT(*) AS total FROM `%s` WHERE %s",
+                $resource['table'],
+                implode(' AND ', $where)
+            );
+
+            $bindings = array_merge($bindings, $partBindings);
+        }
+
+        $rows = DB::select(implode(' UNION ALL ', $parts), $bindings);
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$row->bucket] = (int) $row->total;
+        }
+
+        // Any resource the union somehow skipped still reports a number.
+        foreach (self::RESOURCES as $type => $resource) {
+            $counts[$type] = $counts[$type] ?? 0;
         }
 
         return $counts;
     }
+
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -306,6 +306,10 @@ Route::delete('/competency/library/jobrole-tasks/{id}', [CompetencyLibraryContro
 // One set of routes for all four KASA tabs: {type} is knowledge|ability|attitude|behaviour.
 Route::get('/competency/library/kasa/{type}', [CompetencyLibraryController::class, 'kasa']);
 Route::post('/competency/library/kasa/{type}', [CompetencyLibraryController::class, 'storeKasa']);
+// Where a knowledge / ability / attitude / behaviour item is actually used:
+// which skills reference it, at which levels, and the job roles that inherit
+// it. Declared before the {id} show route so 'usage' is not read as an id.
+Route::get('/competency/library/kasa/{type}/{id}/usage', [CompetencyLibraryController::class, 'usageKasa'])->whereNumber('id');
 Route::get('/competency/library/kasa/{type}/{id}', [CompetencyLibraryController::class, 'showKasa'])->whereNumber('id');
 Route::put('/competency/library/kasa/{type}/{id}', [CompetencyLibraryController::class, 'updateKasa'])->whereNumber('id');
 Route::delete('/competency/library/kasa/{type}/{id}', [CompetencyLibraryController::class, 'destroyKasa'])->whereNumber('id');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to view where competency-library KASA items are used, including linked skills, related job roles, proficiency levels, and usage counts.

- **Performance**
  - Improved library metadata and count retrieval for faster responses.

- **Bug Fixes**
  - Added reliable cache invalidation after library and taxonomy updates.
  - Ensured results respect tenant access, deleted content, shared content, and placeholder filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->